### PR TITLE
Optimize fully unknown linkage matching

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -69,7 +69,7 @@ is_valid_result <- function(
 
   # Only check linkages and anomer if linkages are not ignored
   # These are the most expensive checks, so do them last
-  if (!ignore_linkages) {
+  if (!should_skip_linkage_validation(ignore_linkages, motif)) {
     if (!linkage_check(r, glycan, motif)) {
       return(FALSE)
     }
@@ -79,6 +79,55 @@ is_valid_result <- function(
   }
 
   return(TRUE)
+}
+
+#' Check Whether Linkage Validation Can Be Skipped
+#'
+#' @param ignore_linkages A logical scalar.
+#' @param motif A motif graph.
+#'
+#' @return `TRUE` when linkage and anomer validation cannot further filter
+#'   matched candidates.
+#' @noRd
+should_skip_linkage_validation <- function(ignore_linkages, motif) {
+  if (ignore_linkages) {
+    return(TRUE)
+  }
+
+  motif_linkages <- igraph::E(motif)$linkage
+  if (length(motif_linkages) == 0L) {
+    return(FALSE)
+  }
+
+  is_unknown_anomer(motif$anomer) &&
+    all(purrr::map_lgl(motif_linkages, is_unknown_linkage))
+}
+
+#' Check Whether a Linkage Has No Informative Constraint
+#'
+#' @param linkage A linkage string.
+#'
+#' @return `TRUE` when the linkage does not constrain the anomer or acceptor
+#'   position.
+#' @noRd
+is_unknown_linkage <- function(linkage) {
+  parsed <- parse_linkage(linkage)
+
+  parsed[["anomer"]] == "?" &&
+    parsed[["pos1"]] %in% c("?", "1", "2") &&
+    parsed[["pos2"]] == "?"
+}
+
+#' Check Whether an Anomer Has No Informative Constraint
+#'
+#' @param anomer An anomer string.
+#'
+#' @return `TRUE` when the anomer does not constrain the anomeric state.
+#' @noRd
+is_unknown_anomer <- function(anomer) {
+  parsed <- parse_anomer(anomer)
+
+  parsed[["anomer"]] == "?" && parsed[["pos"]] %in% c("?", "1", "2")
 }
 
 

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -64,6 +64,16 @@
 #' or the half linkage of the glycan.
 #' e.g. Glycan "GlcNAc(b1-4)Gal(a1-" will have both "GlcNAc(b1-" and "Gal(a1-" motifs.
 #'
+#' Linkages such as "?1-?" and "?2-?" are treated as effectively unknown when
+#' the anomer and acceptor position are both unknown.
+#' If all motif linkages and the motif reducing-end anomer are unknown in this way,
+#' linkage and anomer validation is skipped because it cannot further filter candidate matches.
+#' This also means malformed or uncertain input can still match in some cases.
+#' For example, a glycan with "Neu5Ac(?1-?)Gal(?1-" can match a motif
+#' with "Neu5Ac(?2-?)Gal(?1-", and vice versa.
+#' This is acceptable for invalid or uncertain structures;
+#' correct results are only guaranteed for valid input.
+#'
 #' # Alignment
 #'
 #' According to the [GlycoMotif](https://glycomotif.glyomics.org) database,

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -146,6 +146,16 @@ e.g. "GlcNAc(b1-".
 The half linkage in the motif will be matched to any linkage in the glycan,
 or the half linkage of the glycan.
 e.g. Glycan "GlcNAc(b1-4)Gal(a1-" will have both "GlcNAc(b1-" and "Gal(a1-" motifs.
+
+Linkages such as "?1-?" and "?2-?" are treated as effectively unknown when
+the anomer and acceptor position are both unknown.
+If all motif linkages and the motif reducing-end anomer are unknown in this way,
+linkage and anomer validation is skipped because it cannot further filter candidate matches.
+This also means malformed or uncertain input can still match in some cases.
+For example, a glycan with "Neu5Ac(?1-?)Gal(?1-" can match a motif
+with "Neu5Ac(?2-?)Gal(?1-", and vice versa.
+This is acceptable for invalid or uncertain structures;
+correct results are only guaranteed for valid input.
 }
 
 \section{Alignment}{

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -704,6 +704,78 @@ test_that("have_motif works for repeated glycans", {
   expect_equal(result, c(TRUE, TRUE, TRUE, TRUE, FALSE))
 })
 
+test_that("have_motif skips linkage validation when motif linkages are all unknown", {
+  testthat::local_mocked_bindings(
+    linkage_check = function(...) {
+      stop("linkage_check should not be called")
+    },
+    anomer_check = function(...) {
+      stop("anomer_check should not be called")
+    },
+    .package = "glymotif"
+  )
+
+  expect_true(have_motif(
+    "Gal(b1-3)GalNAc(?1-",
+    "Gal(??-?)GalNAc(??-"
+  ))
+})
+
+test_that("have_motif skips linkage validation for unknown anomer with unknown target", {
+  testthat::local_mocked_bindings(
+    linkage_check = function(...) {
+      stop("linkage_check should not be called")
+    },
+    anomer_check = function(...) {
+      stop("anomer_check should not be called")
+    },
+    .package = "glymotif"
+  )
+
+  expect_true(have_motif(
+    "Gal(b1-3)GalNAc(?1-",
+    "Gal(?1-?)GalNAc(?1-"
+  ))
+})
+
+test_that("have_motif skips linkage validation for unknown Neu5Ac anomer with unknown target", {
+  testthat::local_mocked_bindings(
+    linkage_check = function(...) {
+      stop("linkage_check should not be called")
+    },
+    anomer_check = function(...) {
+      stop("anomer_check should not be called")
+    },
+    .package = "glymotif"
+  )
+
+  expect_true(have_motif(
+    "Neu5Ac(a2-3)Gal(?1-",
+    "Neu5Ac(?2-?)Gal(?1-"
+  ))
+})
+
+test_that("have_motif keeps linkage validation when motif has informative linkages", {
+  linkage_checked <- FALSE
+
+  testthat::local_mocked_bindings(
+    linkage_check = function(...) {
+      linkage_checked <<- TRUE
+      TRUE
+    },
+    anomer_check = function(...) {
+      TRUE
+    },
+    .package = "glymotif"
+  )
+
+  expect_true(have_motif(
+    "Gal(b1-3)GalNAc(?1-",
+    "Gal(b1-?)GalNAc(??-"
+  ))
+  expect_true(linkage_checked)
+})
+
 # ========== match_degree ==========
 test_that("match_degree enforces degree constraints on selected nodes", {
   glycan <- glyparse::parse_iupac_condensed("Gal(b1-3)[GlcNAc(b1-6)]GalNAc(a1-")


### PR DESCRIPTION
## Summary

- Skip linkage and anomer validation when motif linkages are effectively all unknown, including `??-?`, `?1-?`, and `?2-?` forms.
- Keep normal linkage validation when any informative motif linkage remains.
- Document the malformed or uncertain input edge case where `?1-?` and `?2-?` can still match because those inputs are treated as effectively unknown.

## Validation

- `devtools::document()`
- `devtools::test(filter = "have-motif")`
- `devtools::test()`
- `air format .`
- `git diff --check`

Closes #18