### PR TITLE
Bypass linkage checks for unlinked motif comparisons

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -81,6 +81,52 @@ is_valid_result <- function(
   return(TRUE)
 }
 
+#' Resolve Linkage Matching Mode
+#'
+#' @param glycan A glycan graph.
+#' @param motif_has_linkages Whether the motif has informative linkages.
+#' @param ignore_linkages Whether linkage matching should be ignored.
+#'
+#' @return One of three linkage modes:
+#'   * `"ignore"`: skip `linkage_check()` and `anomer_check()` because the
+#'     user requested `ignore_linkages = TRUE`, or because the motif has no
+#'     informative linkage constraints to enforce.
+#'   * `"none"`: return no matches before VF2 because the motif has informative
+#'     linkage constraints but the glycan has no informative linkages to match.
+#'   * `"check"`: run the normal VF2 candidate validation with linkage and
+#'     anomer checks enabled.
+#' @noRd
+resolve_linkage_match_mode <- function(
+  glycan,
+  motif_has_linkages,
+  ignore_linkages
+) {
+  # Unlinked motifs are linkage-agnostic: once mono/sub/alignment checks pass,
+  # wildcard linkage checks cannot reject additional candidates.
+  if (ignore_linkages || !motif_has_linkages) {
+    return("ignore")
+  }
+
+  # A linked motif cannot match an unlinked glycan. Returning "none" lets callers
+  # bypass VF2 entirely and return the empty result for their output type.
+  if (!graph_has_linkages(glycan)) {
+    return("none")
+  }
+
+  "check"
+}
+
+#' Determine Whether a Graph Has Informative Linkages
+#'
+#' @param glycan A glycan graph.
+#'
+#' @return A logical scalar.
+#' @noRd
+graph_has_linkages <- function(glycan) {
+  any(igraph::edge_attr(glycan, "linkage") != "??-?") ||
+    igraph::graph_attr(glycan, "anomer") != "??"
+}
+
 
 alignment_check <- function(r, glycan, motif, alignment) {
   switch(

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -188,12 +188,25 @@ count_motif_ <- function(
 .count_motif_single <- function(
   glycan_graph,
   motif_graph,
+  motif_has_linkages,
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL
 ) {
   # This function is the logic part of `count_motif()`.
+  linkage_match_mode <- resolve_linkage_match_mode(
+    glycan_graph,
+    motif_has_linkages,
+    ignore_linkages
+  )
+
+  # "none" is an early no-match result: the motif requires linkage information,
+  # but the glycan has none, so the count must be zero.
+  if (linkage_match_mode == "none") {
+    return(0L)
+  }
+
   c_graphs <- colorize_graphs(glycan_graph, motif_graph)
   glycan_graph <- c_graphs$glycan
   motif_graph <- c_graphs$motif
@@ -204,7 +217,9 @@ count_motif_ <- function(
     glycan = glycan_graph,
     motif = motif_graph,
     alignment = alignment,
-    ignore_linkages = ignore_linkages,
+    # "ignore" still runs VF2 and the non-linkage validators, but bypasses the
+    # expensive linkage/anomer checks inside is_valid_result().
+    ignore_linkages = linkage_match_mode == "ignore",
     strict_sub = strict_sub,
     match_degree = match_degree
   )

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -368,6 +368,7 @@ have_motif_ <- function(
 .have_motif_single <- function(
   glycan_graph,
   motif_graph,
+  motif_has_linkages,
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -375,6 +376,18 @@ have_motif_ <- function(
 ) {
   # Optimized version with early termination
   # Check if any match is valid, returning immediately on first valid match
+  linkage_match_mode <- resolve_linkage_match_mode(
+    glycan_graph,
+    motif_has_linkages,
+    ignore_linkages
+  )
+
+  # "none" is an early no-match result: the motif requires linkage information,
+  # but the glycan has none, so no candidate can become valid.
+  if (linkage_match_mode == "none") {
+    return(FALSE)
+  }
+
   c_graphs <- colorize_graphs(glycan_graph, motif_graph)
   glycan_graph <- c_graphs$glycan
   motif_graph <- c_graphs$motif
@@ -385,7 +398,9 @@ have_motif_ <- function(
     glycan = glycan_graph,
     motif = motif_graph,
     alignment = alignment,
-    ignore_linkages = ignore_linkages,
+    # "ignore" still runs VF2 and the non-linkage validators, but bypasses the
+    # expensive linkage/anomer checks inside is_valid_result().
+    ignore_linkages = linkage_match_mode == "ignore",
     strict_sub = strict_sub,
     match_degree = match_degree
   )

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -279,11 +279,24 @@ match_motifs_ <- function(
 .match_motif_single <- function(
   glycan_graph,
   motif_graph,
+  motif_has_linkages,
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL
 ) {
+  linkage_match_mode <- resolve_linkage_match_mode(
+    glycan_graph,
+    motif_has_linkages,
+    ignore_linkages
+  )
+
+  # "none" is an early no-match result: the motif requires linkage information,
+  # but the glycan has none, so there are no mappings to return.
+  if (linkage_match_mode == "none") {
+    return(list())
+  }
+
   c_graphs <- colorize_graphs(glycan_graph, motif_graph)
   glycan_graph <- c_graphs$glycan
   motif_graph <- c_graphs$motif
@@ -294,7 +307,9 @@ match_motifs_ <- function(
     glycan = glycan_graph,
     motif = motif_graph,
     alignment = alignment,
-    ignore_linkages = ignore_linkages,
+    # "ignore" still runs VF2 and the non-linkage validators, but bypasses the
+    # expensive linkage/anomer checks inside is_valid_result().
+    ignore_linkages = linkage_match_mode == "ignore",
     strict_sub = strict_sub,
     match_degree = match_degree
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -621,10 +621,12 @@ apply_single_motif_to_glycans <- function(
   }
 
   motif_graph <- glyrepr::get_structure_graphs(motif)
+  motif_has_linkages <- glyrepr::has_linkages(motif)[[1]]
   smap_func(
     glycans_to_use,
     single_glycan_func,
     motif_graph,
+    motif_has_linkages,
     alignment,
     ignore_linkages,
     strict_sub,


### PR DESCRIPTION
## Summary
- Add a shared linkage matching mode resolver for motif comparisons, using motif and glycan linkage availability to select normal checking, linkage-agnostic validation, or an early no-match result.
- Bypass linkage/anomer validation when the motif has no informative linkage constraints, while keeping VF2 and the non-linkage validators in place.
- Short-circuit impossible linked-motif versus unlinked-glycan comparisons across `have_motif()`, `match_motif()`, and `count_motif()`, and document the mode semantics in the implementation.

## Testing
- `devtools::document()`
- `devtools::test(filter = "have-motif")`
- `devtools::test(filter = "match-motif")`
- `devtools::test(filter = "count-motif")`
- `devtools::test()`

Closes #18