### PR TITLE
[codex] perf: optimize motif matching with composition prefilter

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -18,6 +18,51 @@ colorize_graphs <- function(glycan, motif) {
   list(glycan_colors = glycan_colors, motif_colors = motif_colors)
 }
 
+#' Create a Motif Composition Profile
+#'
+#' @param motif A motif graph.
+#'
+#' @return A list containing residue keys, required counts, and keying mode.
+#' @noRd
+new_motif_composition_profile <- function(motif) {
+  use_base_keys <- has_fuzzy_modification(motif)
+  motif_monos <- igraph::vertex_attr(motif, "mono")
+  if (use_base_keys) {
+    motif_monos <- residue_color_keys(motif_monos)
+  }
+
+  keys <- unique(motif_monos)
+  counts <- tabulate(match(motif_monos, keys), nbins = length(keys))
+  list(
+    keys = keys,
+    counts = counts,
+    use_base_keys = use_base_keys
+  )
+}
+
+#' Check Whether Glycan Composition Can Contain a Motif
+#'
+#' This is a conservative negative filter. `TRUE` means VF2 is still required;
+#' `FALSE` means the glycan lacks enough residues to contain the motif.
+#'
+#' @param glycan A glycan graph.
+#' @param motif_profile A motif composition profile.
+#'
+#' @return A logical scalar.
+#' @noRd
+composition_can_match <- function(glycan, motif_profile) {
+  glycan_monos <- igraph::vertex_attr(glycan, "mono")
+  if (motif_profile$use_base_keys) {
+    glycan_monos <- residue_color_keys(glycan_monos)
+  }
+
+  glycan_counts <- tabulate(
+    match(glycan_monos, motif_profile$keys),
+    nbins = length(motif_profile$keys)
+  )
+  all(glycan_counts >= motif_profile$counts)
+}
+
 
 #' Check Whether a Motif Has Fuzzy Built-In Modifications
 #'

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -189,6 +189,7 @@ count_motif_ <- function(
   glycan_graph,
   motif_graph,
   motif_has_linkages,
+  motif_composition_profile,
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -204,6 +205,10 @@ count_motif_ <- function(
   # "none" is an early no-match result: the motif requires linkage information,
   # but the glycan has none, so the count must be zero.
   if (linkage_match_mode == "none") {
+    return(0L)
+  }
+
+  if (!composition_can_match(glycan_graph, motif_composition_profile)) {
     return(0L)
   }
 

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -373,6 +373,7 @@ have_motif_ <- function(
   glycan_graph,
   motif_graph,
   motif_has_linkages,
+  motif_composition_profile,
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -389,6 +390,10 @@ have_motif_ <- function(
   # "none" is an early no-match result: the motif requires linkage information,
   # but the glycan has none, so no candidate can become valid.
   if (linkage_match_mode == "none") {
+    return(FALSE)
+  }
+
+  if (!composition_can_match(glycan_graph, motif_composition_profile)) {
     return(FALSE)
   }
 

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -280,6 +280,7 @@ match_motifs_ <- function(
   glycan_graph,
   motif_graph,
   motif_has_linkages,
+  motif_composition_profile,
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -294,6 +295,10 @@ match_motifs_ <- function(
   # "none" is an early no-match result: the motif requires linkage information,
   # but the glycan has none, so there are no mappings to return.
   if (linkage_match_mode == "none") {
+    return(list())
+  }
+
+  if (!composition_can_match(glycan_graph, motif_composition_profile)) {
     return(list())
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -622,11 +622,13 @@ apply_single_motif_to_glycans <- function(
 
   motif_graph <- glyrepr::get_structure_graphs(motif)
   motif_has_linkages <- glyrepr::has_linkages(motif)[[1]]
+  motif_composition_profile <- new_motif_composition_profile(motif_graph)
   smap_func(
     glycans_to_use,
     single_glycan_func,
     motif_graph,
     motif_has_linkages,
+    motif_composition_profile,
     alignment,
     ignore_linkages,
     strict_sub,


### PR DESCRIPTION
## Summary

Adds a conservative composition prefilter before VF2 motif matching. For glycan-motif pairs where the glycan lacks enough residues to contain the motif, the matcher now returns the no-match value before building VF2 colors or running `igraph::graph.get.subisomorphisms.vf2()`.

This affects the internal paths for:

- `have_motif()` / `have_motifs()`
- `count_motif()` / `count_motifs()`
- `match_motif()` / `match_motifs()`

The prefilter preserves the existing fuzzy built-in modification behavior by using the same base residue key logic as VF2 coloring when motifs contain fuzzy substituent positions.

## Benchmark

Compared `perf` (`d7a1113`) against `main` (`48e7d89`) using `glydb::glydb_structures(structure_level = "intact")`.

Method:

- 3 measured reps per workload, warmup excluded
- Glycan sample sizes: 40, 100, 250
- Motifs: 176 unique built-in motif structures from `db_motifs()` with alignments
- Inputs were pre-parsed `glyrepr_structure` objects to focus on matching cost

| Function | Glycans x Motifs | Main median | Perf median | Delta | Speedup |
|---|---:|---:|---:|---:|---:|
| `have_motifs()` | 40 x 176 | 3.855s | 2.599s | 1.256s | 1.48x |
| `have_motifs()` | 100 x 176 | 15.353s | 10.244s | 5.109s | 1.50x |
| `have_motifs()` | 250 x 176 | 57.722s | 38.706s | 19.016s | 1.49x |
| `count_motifs()` | 40 x 176 | 7.730s | 7.016s | 0.714s | 1.10x |
| `count_motifs()` | 100 x 176 | 26.065s | 17.280s | 8.785s | 1.51x |
| `count_motifs()` | 250 x 176 | 70.973s | 51.022s | 19.951s | 1.39x |

Composition mask rejection rate on the same samples:

- 40 glycans: 86.62% rejected before VF2
- 100 glycans: 85.41% rejected before VF2
- 250 glycans: 86.46% rejected before VF2

The benchmark result summaries matched between `main` and `perf` for every benchmark cell.

## Validation

- `devtools::document()`
- `air format R/algorithm.R R/utils.R R/have-motif.R R/count-motif.R R/match-motif.R tests/testthat/test-have-motif.R`
- `devtools::test(filter = "have-motif")`: 174 passed
- `devtools::test()`: 409 passed
- `git diff --check`

Benchmark artifacts were generated locally at:

- `/private/tmp/glymotif-bench.R`
- `/private/tmp/glymotif-main-bench.csv`
- `/private/tmp/glymotif-perf-bench.csv`
- `/private/tmp/glymotif-bench-summary.csv`