### PR TITLE
[codex] Optimize whole-alignment motif matching

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -64,6 +64,24 @@ composition_can_match <- function(glycan, motif_profile) {
 }
 
 
+#' Check Whether Whole-Alignment Graph Sizes Can Match
+#'
+#' @param glycan A glycan graph.
+#' @param motif A motif graph.
+#' @param alignment Alignment mode.
+#'
+#' @return A logical scalar.
+#' @noRd
+whole_alignment_size_can_match <- function(glycan, motif, alignment) {
+  if (alignment != "whole") {
+    return(TRUE)
+  }
+
+  igraph::vcount(glycan) == igraph::vcount(motif) &&
+    igraph::ecount(glycan) == igraph::ecount(motif)
+}
+
+
 #' Check Whether a Motif Has Fuzzy Built-In Modifications
 #'
 #' @param motif A motif graph.

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -196,6 +196,10 @@ count_motif_ <- function(
   match_degree = NULL
 ) {
   # This function is the logic part of `count_motif()`.
+  if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
+    return(0L)
+  }
+
   linkage_match_mode <- resolve_linkage_match_mode(
     glycan_graph,
     motif_has_linkages,

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -381,6 +381,10 @@ have_motif_ <- function(
 ) {
   # Optimized version with early termination
   # Check if any match is valid, returning immediately on first valid match
+  if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
+    return(FALSE)
+  }
+
   linkage_match_mode <- resolve_linkage_match_mode(
     glycan_graph,
     motif_has_linkages,

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -286,6 +286,10 @@ match_motifs_ <- function(
   strict_sub = TRUE,
   match_degree = NULL
 ) {
+  if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
+    return(list())
+  }
+
   linkage_match_mode <- resolve_linkage_match_mode(
     glycan_graph,
     motif_has_linkages,

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -244,6 +244,21 @@ test_that("whole alignment simple negative case", {
   expect_false(have_motif(glycan, motif, alignment = "whole"))
 })
 
+test_that("whole alignment size mismatch returns before composition filtering", {
+  glycan <- glyrepr::o_glycan_core_2()
+  motif <- glyrepr::o_glycan_core_1()
+
+  testthat::local_mocked_bindings(
+    composition_can_match = function(...) {
+      stop("composition filter should not be reached")
+    }
+  )
+
+  expect_false(have_motif(glycan, motif, alignment = "whole"))
+  expect_equal(count_motif(glycan, motif, alignment = "whole"), 0L)
+  expect_equal(match_motif(glycan, motif, alignment = "whole"), list(list()))
+})
+
 
 test_that("whole alignment complex positive case", {
   glycan <- glyrepr::n_glycan_core()


### PR DESCRIPTION
## Summary

Adds an early whole-alignment graph-size prefilter before composition filtering and VF2 matching. For `alignment = "whole"`, glycan/motif pairs with mismatched vertex or edge counts now return immediately for `have_motif()`, `count_motif()`, and `match_motif()` paths.

Also adds regression coverage that verifies whole-alignment size mismatches return before `composition_can_match()` is reached.

## Benchmark

Benchmarked against `main` at `50a654b` and this branch at `2376799` before the test-only follow-up commit. Workload used `db_motifs()` structures: 183 glycans, 75 `whole` motifs, and 32 `substructure` motifs. Each case had a warmup; medians are from 5 reps except `match`, which used 3 reps.

| Case | main median | optimized median | Speedup | Result check |
|---|---:|---:|---:|---|
| `have_motifs(glycans_all, whole_names)` | 3.882s | 0.763s | 5.1x | same `183x75`, sum 87 |
| `count_motifs(glycans_all, whole_names)` | 7.460s | 0.727s | 10.3x | same `183x75`, sum 87 |
| `match_motifs(glycans_all[1:100], whole_names[1:50])` | 3.684s | 0.305s | 12.1x | same outer list length 50 |
| `have_motifs(glycans_all, substructure_names)` | 3.612s | 2.150s | 1.7x | same `183x32`, sum 132 |

I also ran an in-process A/B from the current checkout by toggling the new helper off, which better isolates the prefilter from process/filesystem noise:

| Case | old-mode median | optimized median | Speedup | Result check |
|---|---:|---:|---:|---|
| `have_whole_183x75` | 3.635s | 0.955s | 3.8x | same sum 87 |
| `count_whole_183x75` | 6.593s | 1.428s | 4.6x | same sum 87 |
| `match_whole_100x50` | 3.496s | 0.650s | 5.4x | same list length 50 |
| `have_substructure_183x32` | 3.931s | 3.566s | 1.1x | same sum 132 |

Conservative read: isolated whole-alignment workloads improve by about 3.8x to 5.4x with identical result summaries.

## Validation

- `Rscript -e 'devtools::load_all(); devtools::test(filter = "have-motif")'` -> 174 passed
- `Rscript -e 'devtools::load_all(); devtools::test()'` -> 409 passed

Only observed warning was the existing `testthat` built-under-R-version warning.