### PR TITLE
Warn on mismatched structure levels before motif matching

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -76,6 +76,7 @@ prepare_motif_args <- function(
     single_motif,
     call = call
   )
+  warn_mismatched_structure_levels(glycans, motifs)
 
   new_prepared_motif_args(
     glycans = glycans,
@@ -86,6 +87,54 @@ prepare_motif_args <- function(
     match_degree = match_degree,
     single_motif = single_motif
   )
+}
+
+#' Warn About Mismatched Structure Levels
+#'
+#' Informs users when lower-information `glycans` are matched against
+#' higher-information `motifs`, a common mistake that usually returns no matches.
+#'
+#' @param glycans A normalized glycan structure vector.
+#' @param motifs A normalized motif structure vector.
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+warn_mismatched_structure_levels <- function(glycans, motifs) {
+  glycan_level <- suppressWarnings(glyrepr::get_structure_level(glycans))
+  motif_level <- suppressWarnings(glyrepr::get_structure_level(motifs))
+
+  if (
+    glycan_level == "topological" &&
+      motif_level %in% c("intact", "partial")
+  ) {
+    warn_structure_level_mismatch(glycan_level, motif_level)
+  }
+
+  if (glycan_level == "basic" && motif_level != "basic") {
+    warn_structure_level_mismatch(glycan_level, motif_level)
+  }
+
+  invisible(NULL)
+}
+
+#' Emit Structure-Level Mismatch Warning
+#'
+#' @param glycan_level The aggregate structure level of `glycans`.
+#' @param motif_level The aggregate structure level of `motifs`.
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+warn_structure_level_mismatch <- function(glycan_level, motif_level) {
+  cli::cli_warn(
+    c(
+      "Matching lower-level {.arg glycans} against higher-level {.arg motifs} usually returns no matches.",
+      "i" = "{.arg glycans} have {.val {glycan_level}} structure level, while {.arg motifs} have {.val {motif_level}} structure level.",
+      "i" = "Use motifs at the same structure level as the glycans, or reduce motif structure levels before matching.",
+      "i" = "See {.code ?get_structure_level} for details."
+    ),
+    class = "warning_mismatched_structure_level"
+  )
+  invisible(NULL)
 }
 
 #' Test if an Object is a Motif Specification

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -89,7 +89,34 @@ test_that("concrete glycan and generic motif", {
 test_that("generic glycan and concrete motif", {
   glycan <- glyrepr::o_glycan_core_2(mono_type = "generic")
   motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(?1-")
-  expect_false(have_motif(glycan, motif))
+  expect_warning(
+    expect_false(have_motif(glycan, motif)),
+    class = "warning_mismatched_structure_level"
+  )
+})
+
+test_that("mismatched structure levels warn before returning no matches", {
+  intact <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  partial <- glyrepr::as_glycan_structure("Gal(b1-?)GalNAc(a1-")
+  topological <- glyrepr::reduce_structure_level(intact, "topological")
+  basic <- glyrepr::reduce_structure_level(intact, "basic")
+
+  expect_no_warning(have_motif(intact, topological))
+  expect_no_warning(have_motif(partial, intact))
+
+  expect_warning(
+    expect_false(have_motif(topological, intact)),
+    "See `\\?get_structure_level` for details\\.",
+    class = "warning_mismatched_structure_level"
+  )
+  expect_warning(
+    expect_equal(count_motif(basic, topological), 0L),
+    class = "warning_mismatched_structure_level"
+  )
+  expect_warning(
+    expect_false(have_motifs(topological, c(intact, topological))[[1]]),
+    class = "warning_mismatched_structure_level"
+  )
 })
 
 
@@ -678,9 +705,24 @@ test_that("have_motif: concrete glycan matches generic motif", {
 
 test_that("have_motif: generic glycan does not match concrete motif", {
   # Hex (generic) should not match Man (concrete) - names don't match
-  expect_false(have_motif("Hex(?1-", "Man(?1-"))
-  expect_false(have_motif("Hex(?1-", "Gal(?1-"))
-  expect_false(have_motif("Hex(?1-", "Glc(?1-"))
+  expect_warning(
+    expect_false(
+      have_motif("Hex(?1-", "Man(?1-")
+    ),
+    class = "warning_mismatched_structure_level"
+  )
+  expect_warning(
+    expect_false(
+      have_motif("Hex(?1-", "Gal(?1-")
+    ),
+    class = "warning_mismatched_structure_level"
+  )
+  expect_warning(
+    expect_false(
+      have_motif("Hex(?1-", "Glc(?1-")
+    ),
+    class = "warning_mismatched_structure_level"
+  )
 })
 
 test_that("have_motif: same type matches", {
@@ -702,7 +744,10 @@ test_that("have_motif: complex structures with type conversion", {
   # Reverse should not match
   generic_glycan <- "Hex(b1-3)HexNAc(?1-"
   concrete_motif <- "Gal(b1-3)GalNAc(?1-"
-  expect_false(have_motif(generic_glycan, concrete_motif))
+  expect_warning(
+    expect_false(have_motif(generic_glycan, concrete_motif)),
+    class = "warning_mismatched_structure_level"
+  )
 })
 
 test_that("have_motif: vectorized glycans with single motif", {


### PR DESCRIPTION
## Summary
- Add a warning when glycans and motifs are matched at incompatible structure levels that are likely to produce no results.
- Wire the check into motif argument preparation so `have_motif()`, `count_motif()`, and related helpers surface the warning consistently.
- Extend tests to cover topological vs intact/partial and basic vs non-basic mismatches.

## Testing
- Updated unit tests to verify the new warning class and the no-warning cases for compatible structure levels.
- Not run (not requested).

Closes #34