### PR TITLE
Improve unknown motif errors with GGM suggestions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 * Add `db_motif_info()` to return a tibble of all built-in database motifs, including their names, structures, and alignments. (#35)
 * Expand the built-in motif database to include additional GlycoMotif collections. Now there are 904 unique motifs. (#36)
 
+## Minor improvements and bug fixes
+
+* Unknown GGM motif names now trigger an error with suggestions for similar known motif names. (#39)
+
 # glymotif 0.15.0
 
 ## New features

--- a/R/get-motif.R
+++ b/R/get-motif.R
@@ -222,6 +222,86 @@ is_db_motif_name <- function(name) {
 }
 
 
+#' Suggest Similar Database Motif Names
+#'
+#' Finds close GGM motif names for diagnostics without changing exact,
+#' case-sensitive motif-name resolution.
+#'
+#' @param name A character vector of unresolved motif names.
+#' @param max_distance The maximum edit distance to consider.
+#'
+#' @return A named list of character vectors.
+#' @noRd
+suggest_db_motif_names <- function(name, max_distance = NULL) {
+  checkmate::assert_character(name)
+  candidates <- unique(db_motif_name_info()$name)
+  candidates <- candidates[!is.na(candidates) & candidates != ""]
+
+  purrr::map(
+    name,
+    function(one_name) {
+      distances <- utils::adist(one_name, candidates, ignore.case = FALSE)
+      distances <- as.integer(distances[1, ])
+      threshold <- if (is.null(max_distance)) {
+        max(2L, floor(nchar(one_name) * 0.25))
+      } else {
+        max_distance
+      }
+      best_distance <- min(distances)
+
+      if (best_distance > threshold) {
+        return(character())
+      }
+
+      candidates[distances == best_distance]
+    }
+  ) |>
+    rlang::set_names(name)
+}
+
+
+#' Format Similar Database Motif Name Suggestions
+#'
+#' @param name A character vector of unresolved motif names.
+#'
+#' @return A named character vector of cli message bullets.
+#' @noRd
+format_db_motif_name_suggestions <- function(name) {
+  suggestions <- suggest_db_motif_names(name)
+  suggestions <- suggestions[purrr::map_lgl(suggestions, ~ length(.x) > 0)]
+
+  if (length(suggestions) == 0) {
+    return(character())
+  }
+
+  formatted <- purrr::imap_chr(
+    suggestions,
+    function(suggestion, input) {
+      suggestion_text <- paste0('"', suggestion, '"', collapse = ", ")
+
+      if (length(suggestions) == 1 && length(suggestion) == 1) {
+        return(paste0("Did you mean ", suggestion_text, "?"))
+      }
+
+      paste0("For \"", input, "\", did you mean ", suggestion_text, "?")
+    }
+  )
+
+  rlang::set_names(formatted, rep("i", length(formatted)))
+}
+
+
+#' Guidance for Inspecting Resolvable Database Motif Names
+#'
+#' @return A named character vector of cli message bullets.
+#' @noRd
+db_motif_name_info_guidance <- function() {
+  c(
+    "i" = 'Use `db_motif_info() |> dplyr::filter(source_id == "GGM")` to inspect valid GGM motif names.'
+  )
+}
+
+
 #' Get Database Motif Rows Resolvable by Name
 #'
 #' Only GGM motif names are accepted for legacy character name lookup through
@@ -276,7 +356,11 @@ check_db_motif_names <- function(name) {
   checkmate::assert_character(name)
   if (!all(is_db_motif_name(name))) {
     unknown_names <- name[!is_db_motif_name(name)]
-    cli::cli_abort("Unknown motif: {.val {unknown_names}}.")
+    cli::cli_abort(c(
+      "Unknown motif{?s}: {.val {unknown_names}}.",
+      format_db_motif_name_suggestions(unknown_names),
+      db_motif_name_info_guidance()
+    ))
   }
   invisible(NULL)
 }

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -153,11 +153,14 @@
 #' @param motif One of:
 #'   - A [glyrepr::glycan_structure()] scalar.
 #'   - A glycan structure string, supported by [glyparse::auto_parse()].
-#'   - A GGM database motif name (use [db_motif_info()] to see all available motifs).
+#'   - A GGM database motif name (use `db_motif_info() |> dplyr::filter(source_id == "GGM")`
+#'     to inspect resolvable motif names).
 #' @param motifs One of:
 #'   - A [glyrepr::glycan_structure()] vector.
 #'   - A glycan structure string vector, supported by [glyparse::auto_parse()].
-#'   - A character vector of GGM database motif names (use [db_motif_info()] to see all available motifs).
+#'   - A character vector of GGM database motif names
+#'     (use `db_motif_info() |> dplyr::filter(source_id == "GGM")`
+#'     to inspect resolvable motif names).
 #' @param alignment A character string.
 #'   Possible values are "substructure", "core", "terminal", and "whole".
 #'   If not provided, the value will be decided based on the `motif` argument.

--- a/R/utils.R
+++ b/R/utils.R
@@ -632,8 +632,7 @@ ensure_motifs_are_structures <- function(
             format_db_motif_name_suggestions(motifs),
             db_motif_name_info_guidance()
           ),
-          call = call,
-          parent = cnd
+          call = call
         )
       }
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -465,7 +465,14 @@ get_motif_type <- function(motifs, call = rlang::caller_env()) {
       return("known")
     } else if (any(known_motif_idx)) {
       unknown_motifs <- motifs[!known_motif_idx]
-      cli::cli_abort("Unknown motif: {.val {unknown_motifs}}.", call = call)
+      cli::cli_abort(
+        c(
+          "Unknown motif{?s}: {.val {unknown_motifs}}.",
+          format_db_motif_name_suggestions(unknown_motifs),
+          db_motif_name_info_guidance()
+        ),
+        call = call
+      )
     } else {
       return("iupac")
     }
@@ -604,7 +611,7 @@ ensure_motifs_are_structures <- function(
         cli::cli_abort(
           c(
             base_err_msg,
-            "i" = "Use {.fn db_motif_info} to see all valid GGM motif names."
+            db_motif_name_info_guidance()
           ),
           call = call,
           parent = cnd
@@ -622,7 +629,8 @@ ensure_motifs_are_structures <- function(
           c(
             base_err_msg,
             "x" = "Some motifs are neither valid glycan structures nor GGM database motif names.",
-            "i" = "Use {.fn db_motif_info} to see all valid GGM motif names."
+            format_db_motif_name_suggestions(motifs),
+            db_motif_name_info_guidance()
           ),
           call = call,
           parent = cnd

--- a/man/add_motifs_int.Rd
+++ b/man/add_motifs_int.Rd
@@ -76,7 +76,9 @@ add_motifs_lgl(
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
 \item A glycan structure string vector, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A character vector of GGM database motif names (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A character vector of GGM database motif names
+(use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignments}{A character vector specifying alignment types for each motif.

--- a/man/count_motif.Rd
+++ b/man/count_motif.Rd
@@ -35,7 +35,8 @@ including IUPAC-condensed, WURCS, GlycoCT, and others.
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} scalar.
 \item A glycan structure string, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A GGM database motif name (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignment}{A character string.
@@ -63,7 +64,9 @@ provided, \code{alignment} and \code{alignments} are silently ignored.}
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
 \item A glycan structure string vector, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A character vector of GGM database motif names (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A character vector of GGM database motif names
+(use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignments}{A character vector specifying alignment types for each motif.

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -35,7 +35,8 @@ including IUPAC-condensed, WURCS, GlycoCT, and others.
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} scalar.
 \item A glycan structure string, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A GGM database motif name (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignment}{A character string.
@@ -63,7 +64,9 @@ provided, \code{alignment} and \code{alignments} are silently ignored.}
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
 \item A glycan structure string vector, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A character vector of GGM database motif names (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A character vector of GGM database motif names
+(use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignments}{A character vector specifying alignment types for each motif.

--- a/man/match_motif.Rd
+++ b/man/match_motif.Rd
@@ -35,7 +35,8 @@ including IUPAC-condensed, WURCS, GlycoCT, and others.
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} scalar.
 \item A glycan structure string, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A GGM database motif name (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignment}{A character string.
@@ -63,7 +64,9 @@ provided, \code{alignment} and \code{alignments} are silently ignored.}
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
 \item A glycan structure string vector, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A character vector of GGM database motif names (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A character vector of GGM database motif names
+(use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignments}{A character vector specifying alignment types for each motif.

--- a/man/view_motif.Rd
+++ b/man/view_motif.Rd
@@ -25,7 +25,8 @@ are accepted, including IUPAC-condensed, WURCS, GlycoCT, and others.
 \itemize{
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} scalar.
 \item A glycan structure string, supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-\item A GGM database motif name (use \code{\link[=db_motif_info]{db_motif_info()}} to see all available motifs).
+\item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
+to inspect resolvable motif names).
 }}
 
 \item{alignment}{A character string.

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -89,6 +89,21 @@ test_that("unknown motif name error suggests similar GGM motif names", {
 })
 
 
+test_that("unknown motif name error does not include parser parent details", {
+  err <- rlang::catch_cnd(
+    have_motif("Gal(a1-", "N-Glycan core bisected"),
+    classes = "error"
+  )
+
+  expect_match(
+    conditionMessage(err),
+    'Did you mean "N-glycan core, bisected"\\?'
+  )
+  expect_false(grepl("Caused by error", conditionMessage(err), fixed = TRUE))
+  expect_false(grepl("Can't parse", conditionMessage(err), fixed = TRUE))
+})
+
+
 test_that("GGM motif name resolution remains case-sensitive", {
   glycan <- glyrepr::as_glycan_structure("Gal(b1-4)GlcNAc(?1-")
 

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -67,6 +67,40 @@ test_that("unkown motif name used as input", {
 })
 
 
+test_that("unknown motif name error points to GGM motif info filter", {
+  glycan <- glyrepr::o_glycan_core_2()
+  motif <- "unknown motif name"
+  err <- rlang::catch_cnd(have_motif(glycan, motif), classes = "error")
+
+  expect_true(grepl(
+    'Use `db_motif_info() |> dplyr::filter(source_id == "GGM")` to inspect valid GGM motif names.',
+    conditionMessage(err),
+    fixed = TRUE
+  ))
+})
+
+
+test_that("unknown motif name error suggests similar GGM motif names", {
+  glycan <- glyrepr::o_glycan_core_2()
+  motif <- "O-glycan core 1"
+  err <- rlang::catch_cnd(have_motif(glycan, motif), classes = "error")
+
+  expect_match(conditionMessage(err), 'Did you mean "O-Glycan core 1"\\?')
+})
+
+
+test_that("GGM motif name resolution remains case-sensitive", {
+  glycan <- glyrepr::as_glycan_structure("Gal(b1-4)GlcNAc(?1-")
+
+  expect_no_error(have_motif(glycan, "i antigen"))
+  expect_no_error(have_motif(glycan, "I antigen"))
+  expect_error(
+    have_motif(glycan, "I Antigen"),
+    'Did you mean "I antigen"\\?'
+  )
+})
+
+
 test_that("bad glycan structure", {
   glycan <- "bad structure"
   motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(b1-")


### PR DESCRIPTION
## Summary
- Add edit-distance based suggestions when motif name lookup fails.
- Keep exact GGM motif resolution case-sensitive while improving diagnostics.
- Update user-facing docs to point to the GGM-only motif filter for valid names.
- Remove nested parser parent details from these motif-name errors so the message stays focused.

## Testing
- Added unit coverage for the new suggestion text, guidance line, parser-free errors, and case-sensitive resolution behavior.
- Not run (not requested).

Closes #39