### PR TITLE
Add lenient motif matching mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # glymotif (development version)
 
 * `add_motifs_lgl()` and `add_motifs_int()` are deprecated. Use `dplyr::mutate()` or `glyexp::mutate_var()` with `tibble::as_tibble(have_motifs(...))` or `tibble::as_tibble(count_motifs(...))` instead. (#44)
+* Add `mode = "lenient"` to motif matching functions so lower-information glycans can match more specific motifs while concrete mismatches still fail. (#45)
 
 # glymotif 0.16.1
 

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -1,4 +1,8 @@
-colorize_graphs <- function(glycan, motif) {
+colorize_graphs <- function(glycan, motif, mode = "strict") {
+  if (mode == "lenient") {
+    return(list(glycan_colors = NULL, motif_colors = NULL))
+  }
+
   # Prepare VF2 color vectors from the "mono" vertex attributes without
   # mutating the input graphs.
   glycan_monos <- igraph::V(glycan)$mono
@@ -98,7 +102,8 @@ core_alignment_root_can_match <- function(
   glycan,
   motif,
   alignment,
-  strict_sub
+  strict_sub,
+  mode = "strict"
 ) {
   if (alignment != "core") {
     return(TRUE)
@@ -112,7 +117,8 @@ core_alignment_root_can_match <- function(
     igraph::vertex_attr(glycan, "sub", index = glycan_core),
     igraph::vertex_attr(motif, "mono", index = motif_core),
     igraph::vertex_attr(motif, "sub", index = motif_core),
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
 }
 
@@ -363,6 +369,7 @@ is_valid_result <- function(
   ignore_linkages,
   strict_sub = TRUE,
   match_degree = NULL,
+  mode = "strict",
   context = NULL
 ) {
   # Optimized early exit using most selective checks first
@@ -390,7 +397,8 @@ is_valid_result <- function(
       glycan,
       motif,
       context = context,
-      strict_sub = strict_sub
+      strict_sub = strict_sub,
+      mode = mode
     )
   ) {
     return(FALSE)
@@ -411,10 +419,10 @@ is_valid_result <- function(
   # Only check linkages and anomer if linkages are not ignored
   # These are the most expensive checks, so do them last
   if (!ignore_linkages) {
-    if (!linkage_check(r, glycan, motif, context = context)) {
+    if (!linkage_check(r, glycan, motif, context = context, mode = mode)) {
       return(FALSE)
     }
-    if (!anomer_check(r, glycan, motif, context = context)) {
+    if (!anomer_check(r, glycan, motif, context = context, mode = mode)) {
       return(FALSE)
     }
   }
@@ -438,6 +446,7 @@ residue_check <- function(
   glycan = NULL,
   motif = NULL,
   strict_sub,
+  mode = "strict",
   context = NULL
 ) {
   if (!is.null(context)) {
@@ -458,7 +467,8 @@ residue_check <- function(
       glycan_subs[[i]],
       motif_monos[[i]],
       motif_subs[[i]],
-      strict_sub
+      strict_sub,
+      mode
     )
   })
 }
@@ -481,7 +491,8 @@ residue_check <- function(
 resolve_linkage_match_mode <- function(
   glycan,
   motif_has_linkages,
-  ignore_linkages
+  ignore_linkages,
+  mode = "strict"
 ) {
   # Unlinked motifs are linkage-agnostic: once mono/sub/alignment checks pass,
   # wildcard linkage checks cannot reject additional candidates.
@@ -491,7 +502,7 @@ resolve_linkage_match_mode <- function(
 
   # A linked motif cannot match an unlinked glycan. Returning "none" lets callers
   # bypass VF2 entirely and return the empty result for their output type.
-  if (!graph_has_linkages(glycan)) {
+  if (mode == "strict" && !graph_has_linkages(glycan)) {
     return("none")
   }
 
@@ -597,7 +608,7 @@ degree_check <- function(
 }
 
 
-match_sub <- function(glycan_sub, motif_sub, strict_sub) {
+match_sub <- function(glycan_sub, motif_sub, strict_sub, mode = "strict") {
   # Handle unstrict matching:
   if (!strict_sub && motif_sub == "") {
     return(TRUE)
@@ -622,14 +633,14 @@ match_sub <- function(glycan_sub, motif_sub, strict_sub) {
   # Check if all motif substituents are matched
   motif_matched <- purrr::map_lgl(motif_subs, function(m_sub) {
     any(purrr::map_lgl(glycan_subs, function(g_sub) {
-      match_single_sub(g_sub, m_sub)
+      match_single_sub(g_sub, m_sub, mode = mode)
     }))
   })
 
   # Check if all glycan substituents are matched (unless motif has wildcards)
   glycan_matched <- purrr::map_lgl(glycan_subs, function(g_sub) {
     any(purrr::map_lgl(motif_subs, function(m_sub) {
-      match_single_sub(g_sub, m_sub)
+      match_single_sub(g_sub, m_sub, mode = mode)
     }))
   })
 
@@ -652,11 +663,12 @@ match_residue <- function(
   glycan_sub,
   motif_mono,
   motif_sub,
-  strict_sub
+  strict_sub,
+  mode = "strict"
 ) {
   if (
-    glycan_mono == motif_mono &&
-      match_sub(glycan_sub, motif_sub, strict_sub)
+    match_mono(glycan_mono, motif_mono, mode) &&
+      match_sub(glycan_sub, motif_sub, strict_sub, mode)
   ) {
     return(TRUE)
   }
@@ -666,11 +678,42 @@ match_residue <- function(
   }
 
   built_in <- decompose_builtin_modification(glycan_mono)
-  if (is.null(built_in) || built_in$mono != motif_mono) {
+  if (is.null(built_in) || !match_mono(built_in$mono, motif_mono, mode)) {
     return(FALSE)
   }
 
-  match_sub(combine_subs(built_in$sub, glycan_sub), motif_sub, strict_sub)
+  match_sub(combine_subs(built_in$sub, glycan_sub), motif_sub, strict_sub, mode)
+}
+
+#' Match a Glycan Monosaccharide to a Motif Monosaccharide
+#'
+#' @param glycan_mono Glycan monosaccharide name.
+#' @param motif_mono Motif monosaccharide name.
+#' @param mode Matching mode.
+#'
+#' @return A logical scalar.
+#' @noRd
+match_mono <- function(glycan_mono, motif_mono, mode = "strict") {
+  if (glycan_mono == motif_mono) {
+    return(TRUE)
+  }
+
+  if (mode != "lenient") {
+    return(FALSE)
+  }
+
+  glycan_type <- glyrepr::get_mono_type(glycan_mono)
+  motif_type <- glyrepr::get_mono_type(motif_mono)
+
+  if (glycan_type == "generic" && motif_type == "concrete") {
+    return(glycan_mono == glyrepr::convert_to_generic(motif_mono))
+  }
+
+  if (glycan_type == "concrete" && motif_type == "generic") {
+    return(glyrepr::convert_to_generic(glycan_mono) == motif_mono)
+  }
+
+  FALSE
 }
 
 
@@ -739,7 +782,7 @@ combine_subs <- function(implicit_sub, explicit_sub) {
 }
 
 # Helper function to match a single substituent (handles obscure linkages)
-match_single_sub <- function(glycan_sub, motif_sub) {
+match_single_sub <- function(glycan_sub, motif_sub, mode = "strict") {
   # Extract position and substituent parts
   # Format: "3Me", "6S", "?Me", "?S", etc.
 
@@ -751,7 +794,9 @@ match_single_sub <- function(glycan_sub, motif_sub) {
   glycan_rest <- stringr::str_sub(glycan_sub, 2)
 
   pos_match <- function(motif_pos, glycan_pos) {
-    motif_pos == "?" || motif_pos == glycan_pos
+    motif_pos == "?" ||
+      (mode == "lenient" && glycan_pos == "?") ||
+      motif_pos == glycan_pos
   }
   sub_match <- function(motif_rest, glycan_rest) {
     motif_rest == glycan_rest
@@ -761,7 +806,13 @@ match_single_sub <- function(glycan_sub, motif_sub) {
 }
 
 
-linkage_check <- function(r, glycan = NULL, motif = NULL, context = NULL) {
+linkage_check <- function(
+  r,
+  glycan = NULL,
+  motif = NULL,
+  context = NULL,
+  mode = "strict"
+) {
   if (is.null(context)) {
     edges <- get_corresponding_edges(r, glycan, motif)
     glycan_linkages <- edges$glycan$linkage
@@ -779,7 +830,9 @@ linkage_check <- function(r, glycan = NULL, motif = NULL, context = NULL) {
     motif_linkages <- context$motif_linkages
   }
   for (i in seq_along(glycan_linkages)) {
-    if (!match_linkage(glycan_linkages[[i]], motif_linkages[[i]])) {
+    if (
+      !match_linkage(glycan_linkages[[i]], motif_linkages[[i]], mode = mode)
+    ) {
       return(FALSE)
     }
   }
@@ -807,19 +860,35 @@ get_corresponding_edges <- function(r, glycan, motif) {
 }
 
 
-match_linkage <- function(glycan_linkage, motif_linkage) {
+match_linkage <- function(glycan_linkage, motif_linkage, mode = "strict") {
   gl <- parse_linkage(glycan_linkage)
   ml <- parse_linkage(motif_linkage)
 
   anomer_ok <- function(gl, ml) {
-    ml[["anomer"]] == "?" || ml[["anomer"]] == gl[["anomer"]]
+    ml[["anomer"]] == "?" ||
+      (mode == "lenient" && gl[["anomer"]] == "?") ||
+      ml[["anomer"]] == gl[["anomer"]]
   }
   pos1_ok <- function(gl, ml) {
-    ml[["pos1"]] == "?" || ml[["pos1"]] == gl[["pos1"]]
+    ml[["pos1"]] == "?" ||
+      (mode == "lenient" && gl[["pos1"]] == "?") ||
+      ml[["pos1"]] == gl[["pos1"]]
   }
   pos2_ok <- function(gl, ml) {
-    ml[["pos2"]] == "?" ||
-      all(parse_pos2(gl[["pos2"]]) %in% parse_pos2(ml[["pos2"]]))
+    glycan_pos2 <- parse_pos2(gl[["pos2"]])
+    motif_pos2 <- parse_pos2(ml[["pos2"]])
+
+    if (any(motif_pos2 == "?")) {
+      return(TRUE)
+    }
+    if (mode == "lenient" && any(glycan_pos2 == "?")) {
+      return(TRUE)
+    }
+    if (mode == "lenient") {
+      return(any(glycan_pos2 %in% motif_pos2))
+    }
+
+    all(glycan_pos2 %in% motif_pos2)
   }
 
   anomer_ok(gl, ml) && pos1_ok(gl, ml) && pos2_ok(gl, ml)
@@ -844,7 +913,13 @@ parse_pos2 <- function(pos2) {
 }
 
 
-anomer_check <- function(r, glycan = NULL, motif = NULL, context = NULL) {
+anomer_check <- function(
+  r,
+  glycan = NULL,
+  motif = NULL,
+  context = NULL,
+  mode = "strict"
+) {
   if (is.null(context)) {
     glycan_core <- core_node(glycan)
     motif_core <- core_node(motif)
@@ -852,30 +927,30 @@ anomer_check <- function(r, glycan = NULL, motif = NULL, context = NULL) {
 
     if (matched_g_node == glycan_core) {
       # This means two cores are matched.
-      match_anomer(glycan$anomer, motif$anomer)
+      match_anomer(glycan$anomer, motif$anomer, mode = mode)
     } else {
       # The motif anomer should match a linkage in the glycan.
       linkage <- igraph::incident(glycan, matched_g_node, mode = "in")$linkage
       linkage_anomer <- stringr::str_split_1(linkage, "-")[[1]]
-      match_anomer(linkage_anomer, motif$anomer)
+      match_anomer(linkage_anomer, motif$anomer, mode = mode)
     }
   } else {
     matched_g_node <- r[[context$motif_core]]
 
     if (matched_g_node == context$glycan_core) {
       # This means two cores are matched.
-      match_anomer(context$glycan_anomer, context$motif_anomer)
+      match_anomer(context$glycan_anomer, context$motif_anomer, mode = mode)
     } else {
       # The motif anomer should match a linkage in the glycan.
       linkage <- context$glycan_incoming_linkages[[matched_g_node]]
       linkage_anomer <- stringr::str_split_1(linkage, "-")[[1]]
-      match_anomer(linkage_anomer, context$motif_anomer)
+      match_anomer(linkage_anomer, context$motif_anomer, mode = mode)
     }
   }
 }
 
 
-match_anomer <- function(glycan_anomer, motif_anomer) {
+match_anomer <- function(glycan_anomer, motif_anomer, mode = "strict") {
   # Check if the anomer of the glycan and motif are matched.
   # - "??" in motif will match any anomer and position in glycan.
   # - "?1" in motif will match any anomer at position 1 in glycan.
@@ -885,10 +960,14 @@ match_anomer <- function(glycan_anomer, motif_anomer) {
   ma <- parse_anomer(motif_anomer)
 
   anomer_ok <- function(ga, ma) {
-    ma[["anomer"]] == "?" || ma[["anomer"]] == ga[["anomer"]]
+    ma[["anomer"]] == "?" ||
+      (mode == "lenient" && ga[["anomer"]] == "?") ||
+      ma[["anomer"]] == ga[["anomer"]]
   }
   position_ok <- function(ga, ma) {
-    ma[["pos"]] == "?" || ma[["pos"]] == ga[["pos"]]
+    ma[["pos"]] == "?" ||
+      (mode == "lenient" && ga[["pos"]] == "?") ||
+      ma[["pos"]] == ga[["pos"]]
   }
 
   anomer_ok(ga, ma) && position_ok(ga, ma)

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -627,24 +627,50 @@ match_sub <- function(glycan_sub, motif_sub, strict_sub, mode = "strict") {
   glycan_subs <- glycan_subs[glycan_subs != ""]
   motif_subs <- motif_subs[motif_subs != ""]
 
-  # For strict matching: every motif substituent must match a glycan substituent
-  # and every glycan substituent must be matched by some motif substituent
+  has_one_to_one_sub_match(glycan_subs, motif_subs, mode = mode)
+}
 
-  # Check if all motif substituents are matched
-  motif_matched <- purrr::map_lgl(motif_subs, function(m_sub) {
-    any(purrr::map_lgl(glycan_subs, function(g_sub) {
+#' Check Whether Substituents Have a One-to-One Assignment
+#'
+#' @param glycan_subs Glycan substituent tokens.
+#' @param motif_subs Motif substituent tokens.
+#' @param mode Matching mode.
+#'
+#' @return A logical scalar.
+#' @noRd
+has_one_to_one_sub_match <- function(glycan_subs, motif_subs, mode = "strict") {
+  if (length(glycan_subs) != length(motif_subs)) {
+    return(FALSE)
+  }
+
+  if (length(glycan_subs) == 0L) {
+    return(TRUE)
+  }
+
+  candidates <- purrr::map(glycan_subs, function(g_sub) {
+    which(purrr::map_lgl(motif_subs, function(m_sub) {
       match_single_sub(g_sub, m_sub, mode = mode)
     }))
   })
 
-  # Check if all glycan substituents are matched (unless motif has wildcards)
-  glycan_matched <- purrr::map_lgl(glycan_subs, function(g_sub) {
-    any(purrr::map_lgl(motif_subs, function(m_sub) {
-      match_single_sub(g_sub, m_sub, mode = mode)
-    }))
-  })
+  if (any(lengths(candidates) == 0L)) {
+    return(FALSE)
+  }
 
-  all(motif_matched) && all(glycan_matched)
+  candidates <- candidates[order(lengths(candidates))]
+
+  assign_next_sub <- function(i, used) {
+    if (i > length(candidates)) {
+      return(TRUE)
+    }
+
+    available <- setdiff(candidates[[i]], used)
+    any(purrr::map_lgl(available, function(j) {
+      assign_next_sub(i + 1L, c(used, j))
+    }))
+  }
+
+  assign_next_sub(1L, integer())
 }
 
 

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -91,7 +91,8 @@ count_motif <- function(
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   # Store input names before processing
   glycan_names <- names(glycans)
@@ -103,7 +104,8 @@ count_motif <- function(
     ignore_linkages = ignore_linkages,
     match_degree = match_degree,
     single_motif = TRUE,
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
   result <- rlang::exec("count_motif_", !!!params)
 
@@ -123,7 +125,8 @@ count_motifs <- function(
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   params <- prepare_motif_args(
     glycans = glycans,
@@ -132,7 +135,8 @@ count_motifs <- function(
     ignore_linkages = ignore_linkages,
     match_degree = match_degree,
     single_motif = FALSE,
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
   glycan_names <- prepare_struc_names(glycans, params$glycans)
   # Use names from resolved motifs if available (e.g., from dynamic_motifs/branch_motifs)
@@ -168,7 +172,8 @@ count_motif_ <- function(
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   # This function is a simpler version of `count_motif()`.
   # It performs the logic directly without argument validations and conversions.
@@ -180,6 +185,7 @@ count_motif_ <- function(
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_glycan_func = .count_motif_single,
     smap_func = glyrepr::smap_int
   )
@@ -193,7 +199,8 @@ count_motif_ <- function(
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   # This function is the logic part of `count_motif()`.
   if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
@@ -204,7 +211,8 @@ count_motif_ <- function(
       glycan_graph,
       motif_graph,
       alignment,
-      strict_sub = strict_sub
+      strict_sub = strict_sub,
+      mode = mode
     )
   ) {
     return(0L)
@@ -213,7 +221,8 @@ count_motif_ <- function(
   linkage_match_mode <- resolve_linkage_match_mode(
     glycan_graph,
     motif_has_linkages,
-    ignore_linkages
+    ignore_linkages,
+    mode = mode
   )
 
   # "none" is an early no-match result: the motif requires linkage information,
@@ -222,11 +231,14 @@ count_motif_ <- function(
     return(0L)
   }
 
-  if (!composition_can_match(glycan_graph, motif_composition_profile)) {
+  if (
+    mode == "strict" &&
+      !composition_can_match(glycan_graph, motif_composition_profile)
+  ) {
     return(0L)
   }
 
-  c_graphs <- colorize_graphs(glycan_graph, motif_graph)
+  c_graphs <- colorize_graphs(glycan_graph, motif_graph, mode = mode)
   res <- perform_vf2(
     glycan_graph,
     motif_graph,
@@ -255,7 +267,8 @@ count_motif_ <- function(
     # expensive linkage/anomer checks inside is_valid_result().
     ignore_linkages = linkage_match_mode == "ignore",
     strict_sub = strict_sub,
-    match_degree = match_degree
+    match_degree = match_degree,
+    mode = mode
   )
   valid_res <- res[valid_mask]
   length(unique_vf2_res(valid_res))
@@ -280,7 +293,8 @@ count_motifs_ <- function(
   motif_names,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   apply_motifs_to_glycans(
     glycans,
@@ -291,6 +305,7 @@ count_motifs_ <- function(
     glycan_names,
     motif_names,
     strict_sub,
-    match_degree
+    match_degree,
+    mode
   )
 }

--- a/R/g-motif.R
+++ b/R/g-motif.R
@@ -15,11 +15,14 @@
 #' @param match_degree A logical vector indicating which motif nodes must match
 #'   the glycan's in- and out-degree exactly. A scalar is recycled to the
 #'   number of motif nodes.
+#' @param mode Matching mode. `"strict"` preserves the default behavior;
+#'   `"lenient"` treats glycan-side unknowns as compatible with more specific
+#'   motif fields.
 #'
 #' @details
 #' These functions do no validation, parsing, naming, or monosaccharide-type
 #' conversion. Callers must provide valid, already-compatible graph objects.
-#' In particular, when matching a generic motif graph, callers must pass a
+#' In strict mode, when matching a generic motif graph, callers must pass a
 #' glycan graph whose `mono` vertex attributes have already been converted to
 #' the compatible generic representation.
 #'
@@ -43,7 +46,8 @@ NULL
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
@@ -52,6 +56,7 @@ NULL
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_glycan_func = .have_motif_single
   )
 }
@@ -64,7 +69,8 @@ NULL
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
@@ -73,6 +79,7 @@ NULL
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_glycan_func = .count_motif_single
   )
 }
@@ -85,7 +92,8 @@ NULL
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
@@ -94,6 +102,7 @@ NULL
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_glycan_func = .match_motif_single
   )
 }
@@ -106,6 +115,7 @@ NULL
 #' @param ignore_linkages A logical scalar.
 #' @param strict_sub A logical scalar.
 #' @param match_degree A logical vector or `NULL`.
+#' @param mode Matching mode.
 #' @param single_glycan_func A graph-level motif matching function.
 #'
 #' @return The result from `single_glycan_func`.
@@ -117,8 +127,10 @@ apply_single_motif_to_graph <- function(
   ignore_linkages,
   strict_sub,
   match_degree,
+  mode,
   single_glycan_func
 ) {
+  mode <- rlang::arg_match(mode, c("strict", "lenient"))
   motif_has_linkages <- graph_has_linkages(motif_graph)
   motif_composition_profile <- new_motif_composition_profile(motif_graph)
   match_degree <- normalize_graph_match_degree(match_degree, motif_graph)
@@ -131,7 +143,8 @@ apply_single_motif_to_graph <- function(
     alignment = alignment,
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
-    match_degree = match_degree
+    match_degree = match_degree,
+    mode = mode
   )
 }
 

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -42,6 +42,10 @@
 #' - `Man` (concrete glycan) vs `Man` (concrete motif) → TRUE (exact match)
 #' - `Hex` (generic glycan) vs `Hex` (generic motif) → TRUE (exact match)
 #'
+#' With `mode = "lenient"`, generic glycan residues can match compatible
+#' concrete motif residues. For example, `Hex` can match a `Gal` motif residue,
+#' but `HexNAc` still cannot match `Gal`.
+#'
 #' # Linkages
 #'
 #' Obscure linkages (e.g. "??-?") are allowed in the `motif` graph
@@ -63,6 +67,17 @@
 #' The half linkage in the motif will be matched to any linkage in the glycan,
 #' or the half linkage of the glycan.
 #' e.g. Glycan "GlcNAc(b1-4)Gal(a1-" will have both "GlcNAc(b1-" and "Gal(a1-" motifs.
+#'
+#' # Matching mode
+#'
+#' `mode = "strict"` is the default and preserves the standard rule that
+#' glycans cannot be more obscure than motifs. For example,
+#' "Gal(?1-?)GalNAc(?1-" does not match "Gal(b1-3)GalNAc(a1-".
+#'
+#' `mode = "lenient"` treats obscure glycan-side monosaccharides, linkages,
+#' substituent positions, and reducing-end anomers as compatible with more
+#' specific motif fields. Concrete mismatches still fail: for example,
+#' "Gal(?1-6)GalNAc(a1-" does not match "Gal(b1-3)GalNAc(a1-".
 #'
 #' # Alignment
 #'
@@ -180,6 +195,10 @@
 #' @param strict_sub A logical value. If `TRUE` (default), substituents will be matched in strict mode,
 #'   which means if the glycan has a substituent in some residue,
 #'   the motif must have the same substituent to be matched.
+#' @param mode Matching mode. `"strict"` preserves the default behavior where
+#'   glycans cannot be more obscure than motifs. `"lenient"` treats glycan-side
+#'   obscure fields as compatible with more specific motif fields while still
+#'   rejecting concrete mismatches.
 #'
 #' @returns
 #' - `have_motif()`: A logical vector indicating if each `glycan` has the `motif`.
@@ -283,7 +302,8 @@ have_motif <- function(
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   # Store input names before processing
   glycan_names <- names(glycans)
@@ -295,7 +315,8 @@ have_motif <- function(
     ignore_linkages = ignore_linkages,
     match_degree = match_degree,
     single_motif = TRUE,
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
   result <- rlang::exec("have_motif_", !!!params)
 
@@ -315,7 +336,8 @@ have_motifs <- function(
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   params <- prepare_motif_args(
     glycans = glycans,
@@ -324,7 +346,8 @@ have_motifs <- function(
     ignore_linkages = ignore_linkages,
     match_degree = match_degree,
     single_motif = FALSE,
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
   glycan_names <- prepare_struc_names(glycans, params$glycans)
   # Use names from resolved motifs if available (e.g., from dynamic_motifs/branch_motifs)
@@ -359,7 +382,8 @@ have_motif_ <- function(
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   # This function is a simpler version of `have_motif()`.
   # It performs the logic directly without argument validations and conversions.
@@ -371,6 +395,7 @@ have_motif_ <- function(
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_glycan_func = .have_motif_single,
     smap_func = glyrepr::smap_lgl
   )
@@ -384,7 +409,8 @@ have_motif_ <- function(
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   # Optimized version with early termination
   # Check if any match is valid, returning immediately on first valid match
@@ -396,7 +422,8 @@ have_motif_ <- function(
       glycan_graph,
       motif_graph,
       alignment,
-      strict_sub = strict_sub
+      strict_sub = strict_sub,
+      mode = mode
     )
   ) {
     return(FALSE)
@@ -405,7 +432,8 @@ have_motif_ <- function(
   linkage_match_mode <- resolve_linkage_match_mode(
     glycan_graph,
     motif_has_linkages,
-    ignore_linkages
+    ignore_linkages,
+    mode = mode
   )
 
   # "none" is an early no-match result: the motif requires linkage information,
@@ -414,11 +442,14 @@ have_motif_ <- function(
     return(FALSE)
   }
 
-  if (!composition_can_match(glycan_graph, motif_composition_profile)) {
+  if (
+    mode == "strict" &&
+      !composition_can_match(glycan_graph, motif_composition_profile)
+  ) {
     return(FALSE)
   }
 
-  c_graphs <- colorize_graphs(glycan_graph, motif_graph)
+  c_graphs <- colorize_graphs(glycan_graph, motif_graph, mode = mode)
   res <- perform_vf2(
     glycan_graph,
     motif_graph,
@@ -456,7 +487,8 @@ have_motif_ <- function(
     # expensive linkage/anomer checks inside is_valid_result().
     ignore_linkages = linkage_match_mode == "ignore",
     strict_sub = strict_sub,
-    match_degree = match_degree
+    match_degree = match_degree,
+    mode = mode
   )
 }
 
@@ -480,7 +512,8 @@ have_motifs_ <- function(
   motif_names,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   apply_motifs_to_glycans(
     glycans,
@@ -491,6 +524,7 @@ have_motifs_ <- function(
     glycan_names,
     motif_names,
     strict_sub,
-    match_degree
+    match_degree,
+    mode
   )
 }

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -72,12 +72,14 @@
 #'
 #' `mode = "strict"` is the default and preserves the standard rule that
 #' glycans cannot be more obscure than motifs. For example,
-#' "Gal(?1-?)GalNAc(?1-" does not match "Gal(b1-3)GalNAc(a1-".
+#' glycan "Gal(?1-?)GalNAc(?1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 #'
 #' `mode = "lenient"` treats obscure glycan-side monosaccharides, linkages,
 #' substituent positions, and reducing-end anomers as compatible with more
-#' specific motif fields. Concrete mismatches still fail: for example,
-#' "Gal(?1-6)GalNAc(a1-" does not match "Gal(b1-3)GalNAc(a1-".
+#' specific motif fields. In the lenient mode,
+#' glycan "Gal(?1-?)GalNAc(?1-" matches motif "Gal(b1-3)GalNAc(a1-".
+#' Concrete mismatches still fail: for example,
+#' glycan "Gal(?1-6)GalNAc(a1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 #'
 #' # Alignment
 #'

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -92,7 +92,8 @@ match_motif <- function(
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   # Store input names before processing
   glycan_names <- names(glycans)
@@ -106,7 +107,8 @@ match_motif <- function(
     ignore_linkages = ignore_linkages,
     match_degree = match_degree,
     single_motif = TRUE,
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
   result <- rlang::exec("match_motif_", !!!params)
 
@@ -126,7 +128,8 @@ match_motifs <- function(
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 ) {
   # Validate glycans first (must be glycan_structure)
   .assert_glycan_structure(glycans, "glycans")
@@ -142,7 +145,8 @@ match_motifs <- function(
     ignore_linkages = ignore_linkages,
     match_degree = match_degree,
     single_motif = FALSE,
-    strict_sub = strict_sub
+    strict_sub = strict_sub,
+    mode = mode
   )
 
   # Validate resolved motifs (must be glycan_structure, not raw strings)
@@ -204,7 +208,8 @@ match_motif_ <- function(
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   apply_single_motif_to_glycans(
     glycans = glycans,
@@ -213,6 +218,7 @@ match_motif_ <- function(
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_glycan_func = .match_motif_single,
     smap_func = glyrepr::smap
   )
@@ -236,7 +242,8 @@ match_motifs_ <- function(
   motif_names,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   match_degree_list <- if (is.null(match_degree)) {
     rep(list(NULL), length(motifs))
@@ -253,7 +260,8 @@ match_motifs_ <- function(
       alignment = alignments[[.y]],
       ignore_linkages = ignore_linkages,
       strict_sub = strict_sub,
-      match_degree = match_degree_list[[.y]]
+      match_degree = match_degree_list[[.y]],
+      mode = mode
     )
   )
 
@@ -284,7 +292,8 @@ match_motifs_ <- function(
   alignment,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = "strict"
 ) {
   if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
     return(list())
@@ -294,7 +303,8 @@ match_motifs_ <- function(
       glycan_graph,
       motif_graph,
       alignment,
-      strict_sub = strict_sub
+      strict_sub = strict_sub,
+      mode = mode
     )
   ) {
     return(list())
@@ -303,7 +313,8 @@ match_motifs_ <- function(
   linkage_match_mode <- resolve_linkage_match_mode(
     glycan_graph,
     motif_has_linkages,
-    ignore_linkages
+    ignore_linkages,
+    mode = mode
   )
 
   # "none" is an early no-match result: the motif requires linkage information,
@@ -312,11 +323,14 @@ match_motifs_ <- function(
     return(list())
   }
 
-  if (!composition_can_match(glycan_graph, motif_composition_profile)) {
+  if (
+    mode == "strict" &&
+      !composition_can_match(glycan_graph, motif_composition_profile)
+  ) {
     return(list())
   }
 
-  c_graphs <- colorize_graphs(glycan_graph, motif_graph)
+  c_graphs <- colorize_graphs(glycan_graph, motif_graph, mode = mode)
   res <- perform_vf2(
     glycan_graph,
     motif_graph,
@@ -345,7 +359,8 @@ match_motifs_ <- function(
     # expensive linkage/anomer checks inside is_valid_result().
     ignore_linkages = linkage_match_mode == "ignore",
     strict_sub = strict_sub,
-    match_degree = match_degree
+    match_degree = match_degree,
+    mode = mode
   )
   valid_res <- res[valid_mask]
   unique_res <- unique_vf2_res(valid_res)

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,6 +11,7 @@
 #' @param match_degree Optional degree-matching mask.
 #' @param single_motif Whether the caller expects exactly one motif.
 #' @param strict_sub Whether substituent matching should be strict.
+#' @param mode Matching mode.
 #' @param call The call environment used for errors.
 #'
 #' @return A normalized argument list for single- or multiple-motif internals.
@@ -23,8 +24,11 @@ prepare_motif_args <- function(
   match_degree = NULL,
   single_motif = FALSE,
   strict_sub = TRUE,
+  mode = "strict",
   call = rlang::caller_env()
 ) {
+  mode <- rlang::arg_match(mode, c("strict", "lenient"))
+
   prepared <- if (is_motif_spec(motifs)) {
     prepare_spec_motif_args(
       glycans,
@@ -76,7 +80,9 @@ prepare_motif_args <- function(
     single_motif,
     call = call
   )
-  warn_mismatched_structure_levels(glycans, motifs)
+  if (mode == "strict") {
+    warn_mismatched_structure_levels(glycans, motifs)
+  }
 
   new_prepared_motif_args(
     glycans = glycans,
@@ -85,6 +91,7 @@ prepare_motif_args <- function(
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
+    mode = mode,
     single_motif = single_motif
   )
 }
@@ -294,27 +301,29 @@ new_prepared_motif_args <- function(
   ignore_linkages,
   strict_sub,
   match_degree,
+  mode,
   single_motif
 ) {
   common_args <- list(
     glycans = glycans,
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
-    match_degree = match_degree
+    match_degree = match_degree,
+    mode = mode
   )
 
   if (single_motif) {
     return(c(
       common_args["glycans"],
       list(motif = motifs, alignment = alignments),
-      common_args[c("ignore_linkages", "strict_sub", "match_degree")]
+      common_args[c("ignore_linkages", "strict_sub", "match_degree", "mode")]
     ))
   }
 
   c(
     common_args["glycans"],
     list(motifs = motifs, alignments = alignments),
-    common_args[c("ignore_linkages", "strict_sub", "match_degree")]
+    common_args[c("ignore_linkages", "strict_sub", "match_degree", "mode")]
   )
 }
 
@@ -663,6 +672,7 @@ apply_single_motif_to_glycans <- function(
   ignore_linkages,
   strict_sub,
   match_degree,
+  mode,
   single_glycan_func,
   smap_func
 ) {
@@ -695,7 +705,8 @@ apply_single_motif_to_glycans <- function(
     alignment,
     ignore_linkages,
     strict_sub,
-    match_degree
+    match_degree,
+    mode
   )
 }
 
@@ -786,7 +797,8 @@ apply_motifs_to_glycans <- function(
   glycan_names,
   motif_names,
   strict_sub,
-  match_degree
+  match_degree,
+  mode
 ) {
   # Generic function to apply multiple motifs to multiple glycans
   # single_motif_func should be either have_motif_ or count_motif_
@@ -812,7 +824,8 @@ apply_motifs_to_glycans <- function(
       alignment = alignments[[.y]],
       ignore_linkages = ignore_linkages,
       strict_sub = strict_sub,
-      match_degree = match_degree_list[[.y]]
+      match_degree = match_degree_list[[.y]],
+      mode = mode
     )
   )
 

--- a/man/count_motif.Rd
+++ b/man/count_motif.Rd
@@ -11,7 +11,8 @@ count_motif(
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 
 count_motifs(
@@ -20,7 +21,8 @@ count_motifs(
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 }
 \arguments{
@@ -59,6 +61,11 @@ motif nodes (length 1 is recycled). For \code{have_motifs()}, \code{count_motifs
 \code{match_motifs()}, this must be a list of logical vectors with length equal to
 \code{motifs}; each element follows the same length rules. When \code{match_degree} is
 provided, \code{alignment} and \code{alignments} are silently ignored.}
+
+\item{mode}{Matching mode. \code{"strict"} preserves the default behavior where
+glycans cannot be more obscure than motifs. \code{"lenient"} treats glycan-side
+obscure fields as compatible with more specific motif fields while still
+rejecting concrete mismatches.}
 
 \item{motifs}{One of:
 \itemize{

--- a/man/dot-g_motif.Rd
+++ b/man/dot-g_motif.Rd
@@ -13,7 +13,8 @@
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 
 .g_count_motif(
@@ -22,7 +23,8 @@
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 
 .g_match_motif(
@@ -31,7 +33,8 @@
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 }
 \arguments{
@@ -50,6 +53,10 @@ strictly.}
 \item{match_degree}{A logical vector indicating which motif nodes must match
 the glycan's in- and out-degree exactly. A scalar is recycled to the
 number of motif nodes.}
+
+\item{mode}{Matching mode. \code{"strict"} preserves the default behavior;
+\code{"lenient"} treats glycan-side unknowns as compatible with more specific
+motif fields.}
 }
 \value{
 \itemize{
@@ -66,7 +73,7 @@ objects from \code{\link[glyrepr:get_structure_graphs]{glyrepr::get_structure_gr
 \details{
 These functions do no validation, parsing, naming, or monosaccharide-type
 conversion. Callers must provide valid, already-compatible graph objects.
-In particular, when matching a generic motif graph, callers must pass a
+In strict mode, when matching a generic motif graph, callers must pass a
 glycan graph whose \code{mono} vertex attributes have already been converted to
 the compatible generic representation.
 

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -11,7 +11,8 @@ have_motif(
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 
 have_motifs(
@@ -20,7 +21,8 @@ have_motifs(
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 }
 \arguments{
@@ -59,6 +61,11 @@ motif nodes (length 1 is recycled). For \code{have_motifs()}, \code{count_motifs
 \code{match_motifs()}, this must be a list of logical vectors with length equal to
 \code{motifs}; each element follows the same length rules. When \code{match_degree} is
 provided, \code{alignment} and \code{alignments} are silently ignored.}
+
+\item{mode}{Matching mode. \code{"strict"} preserves the default behavior where
+glycans cannot be more obscure than motifs. \code{"lenient"} treats glycan-side
+obscure fields as compatible with more specific motif fields while still
+rejecting concrete mismatches.}
 
 \item{motifs}{One of:
 \itemize{
@@ -125,6 +132,10 @@ Examples:
 \item \code{Man} (concrete glycan) vs \code{Man} (concrete motif) → TRUE (exact match)
 \item \code{Hex} (generic glycan) vs \code{Hex} (generic motif) → TRUE (exact match)
 }
+
+With \code{mode = "lenient"}, generic glycan residues can match compatible
+concrete motif residues. For example, \code{Hex} can match a \code{Gal} motif residue,
+but \code{HexNAc} still cannot match \code{Gal}.
 }
 
 \section{Linkages}{
@@ -149,6 +160,17 @@ e.g. "GlcNAc(b1-".
 The half linkage in the motif will be matched to any linkage in the glycan,
 or the half linkage of the glycan.
 e.g. Glycan "GlcNAc(b1-4)Gal(a1-" will have both "GlcNAc(b1-" and "Gal(a1-" motifs.
+}
+
+\section{Matching mode}{
+\code{mode = "strict"} is the default and preserves the standard rule that
+glycans cannot be more obscure than motifs. For example,
+"Gal(?1-?)GalNAc(?1-" does not match "Gal(b1-3)GalNAc(a1-".
+
+\code{mode = "lenient"} treats obscure glycan-side monosaccharides, linkages,
+substituent positions, and reducing-end anomers as compatible with more
+specific motif fields. Concrete mismatches still fail: for example,
+"Gal(?1-6)GalNAc(a1-" does not match "Gal(b1-3)GalNAc(a1-".
 }
 
 \section{Alignment}{

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -165,12 +165,14 @@ e.g. Glycan "GlcNAc(b1-4)Gal(a1-" will have both "GlcNAc(b1-" and "Gal(a1-" moti
 \section{Matching mode}{
 \code{mode = "strict"} is the default and preserves the standard rule that
 glycans cannot be more obscure than motifs. For example,
-"Gal(?1-?)GalNAc(?1-" does not match "Gal(b1-3)GalNAc(a1-".
+glycan "Gal(?1-?)GalNAc(?1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 
 \code{mode = "lenient"} treats obscure glycan-side monosaccharides, linkages,
 substituent positions, and reducing-end anomers as compatible with more
-specific motif fields. Concrete mismatches still fail: for example,
-"Gal(?1-6)GalNAc(a1-" does not match "Gal(b1-3)GalNAc(a1-".
+specific motif fields. In the lenient mode,
+glycan "Gal(?1-?)GalNAc(?1-" matches motif "Gal(b1-3)GalNAc(a1-".
+Concrete mismatches still fail: for example,
+glycan "Gal(?1-6)GalNAc(a1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 }
 
 \section{Alignment}{

--- a/man/match_motif.Rd
+++ b/man/match_motif.Rd
@@ -11,7 +11,8 @@ match_motif(
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 
 match_motifs(
@@ -20,7 +21,8 @@ match_motifs(
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
-  match_degree = NULL
+  match_degree = NULL,
+  mode = c("strict", "lenient")
 )
 }
 \arguments{
@@ -59,6 +61,11 @@ motif nodes (length 1 is recycled). For \code{have_motifs()}, \code{count_motifs
 \code{match_motifs()}, this must be a list of logical vectors with length equal to
 \code{motifs}; each element follows the same length rules. When \code{match_degree} is
 provided, \code{alignment} and \code{alignments} are silently ignored.}
+
+\item{mode}{Matching mode. \code{"strict"} preserves the default behavior where
+glycans cannot be more obscure than motifs. \code{"lenient"} treats glycan-side
+obscure fields as compatible with more specific motif fields while still
+rejecting concrete mismatches.}
 
 \item{motifs}{One of:
 \itemize{

--- a/tests/testthat/test-count-motif.R
+++ b/tests/testthat/test-count-motif.R
@@ -363,3 +363,12 @@ test_that("count_motifs returns trimmed IUPAC strings as colnames for branch_mot
   # Column names should end with the branch root linkage pattern
   expect_true(all(grepl("\\([a-z]1-$", colnames(result))))
 })
+
+# ========== Lenient Mode ==========
+test_that("count_motif supports lenient mode", {
+  glycan <- "Hex(??-?)HexNAc(??-"
+  motif <- "Gal(b1-3)GalNAc(a1-"
+
+  expect_equal(suppressWarnings(count_motif(glycan, motif)), 0L)
+  expect_equal(count_motif(glycan, motif, mode = "lenient"), 1L)
+})

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -1124,3 +1124,63 @@ test_that("have_motifs returns trimmed IUPAC strings as colnames for branch_moti
   # Column names should end with the branch root linkage pattern (e.g., "GlcNAc(b1-")
   expect_true(all(grepl("\\([a-z]1-$", colnames(result))))
 })
+
+# ========== Lenient Mode ==========
+test_that("lenient mode ignores obscure linkages", {
+  glycans <- c(
+    "Gal(b1-?)GalNAc(a1-",
+    "Gal(?1-3)GalNAc(a1-",
+    "Gal(b?-3)GalNAc(a1-",
+    "Gal(b1-3/6)GalNAc(a1-",
+    "Gal(??-?)GalNAc(a1-",
+    "Gal(?1-6)GalNAc(a1-",
+    "Gal(b1-4/6)GalNAc(a1-"
+  )
+  motif <- "Gal(b1-3)GalNAc(a1-"
+  result <- have_motif(glycans, motif, mode = "lenient")
+  expected <- c(TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE)
+  expect_identical(result, expected)
+})
+
+test_that("lenient mode ignores obscure reducing end anomers", {
+  glycans <- c(
+    "Gal(b1-3)GalNAc(?1-",
+    "Gal(b1-3)GalNAc(a?-",
+    "Gal(b1-3)GalNAc(b?-"
+  )
+  motif <- "Gal(b1-3)GalNAc(a1-"
+  result <- have_motif(glycans, motif, mode = "lenient")
+  expected <- c(TRUE, TRUE, FALSE)
+  expect_identical(result, expected)
+})
+
+test_that("lenient mode matches generic to concrete monosaccharides", {
+  glycans <- c("Hex(??-?)HexNAc(??-", "HexNAc(??-?)HexNAc(??-")
+  motif <- "Gal(??-?)GalNAc(??-"
+  result <- have_motif(glycans, motif, mode = "lenient")
+  expected <- c(TRUE, FALSE)
+  expect_identical(result, expected)
+})
+
+test_that("lenient mode ignores obscure substituent linkages", {
+  glycans <- c(
+    "Glc?Me6S(?1-",
+    "Glc3Me?S(?1-",
+    "Glc4Me6S(?1-",
+    "Glc3Me4S(?1-"
+  )
+  motif <- "Glc3Me6S(?1-"
+
+  expect_false(have_motif(glycans[[1]], motif))
+  expect_identical(
+    have_motif(glycans, motif, mode = "lenient"),
+    c(TRUE, TRUE, FALSE, FALSE)
+  )
+})
+
+test_that("mode is validated", {
+  expect_error(
+    have_motif("Gal(?1-", "Gal(a1-", mode = "loose"),
+    "`mode` must be"
+  )
+})

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -1178,6 +1178,40 @@ test_that("lenient mode ignores obscure substituent linkages", {
   )
 })
 
+test_that("lenient mode matches substituents one-to-one", {
+  repeated_unknown_glycan <- glyparse::parse_iupac_condensed("Glc?Me(?1-")
+  graphs <- attr(repeated_unknown_glycan, "graphs")
+  graphs[[1]] <- igraph::set_vertex_attr(
+    graphs[[1]],
+    "sub",
+    value = "?Me,?Me"
+  )
+  attr(repeated_unknown_glycan, "graphs") <- graphs
+
+  single_unknown_glycan <- glyparse::parse_iupac_condensed("Glc?Me(?1-")
+
+  expect_true(have_motif(
+    single_unknown_glycan,
+    "Glc3Me(?1-",
+    mode = "lenient"
+  ))
+  expect_false(have_motif(
+    single_unknown_glycan,
+    "Glc3Me4Me(?1-",
+    mode = "lenient"
+  ))
+  expect_false(have_motif(
+    repeated_unknown_glycan,
+    "Glc3Me(?1-",
+    mode = "lenient"
+  ))
+  expect_true(have_motif(
+    repeated_unknown_glycan,
+    "Glc3Me4Me(?1-",
+    mode = "lenient"
+  ))
+})
+
 test_that("mode is validated", {
   expect_error(
     have_motif("Gal(?1-", "Gal(a1-", mode = "loose"),

--- a/tests/testthat/test-match-motif.R
+++ b/tests/testthat/test-match-motif.R
@@ -534,3 +534,18 @@ test_that("match_motifs returns trimmed IUPAC strings as outer list names for br
   # Names should end with the branch root linkage pattern
   expect_true(all(grepl("\\([a-z]1-$", names(result))))
 })
+
+# ========== Lenient Mode ==========
+test_that("match_motif supports lenient mode", {
+  glycan <- glyparse::parse_iupac_condensed("Hex(??-?)HexNAc(??-")
+  motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(a1-")
+
+  expect_match_motif_equal(
+    suppressWarnings(match_motif(glycan, motif)),
+    list(list())
+  )
+  expect_match_motif_equal(
+    match_motif(glycan, motif, mode = "lenient"),
+    list(list(c(1, 2)))
+  )
+})


### PR DESCRIPTION
## Summary

Add `mode = c("strict", "lenient")` to motif matching so users can opt into matching lower-information glycans against more specific motifs.

## Background

Issue #43 requests a lenient mode where obscure glycan-side components are not compared against more specific motif fields, while concrete mismatches still fail.

## Details

- Keeps `mode = "strict"` as the default behavior.
- Adds `mode = "lenient"` to `have_*`, `count_*`, `match_*`, and graph-level `.g_*` motif helpers.
- Treats glycan-side generic monosaccharides, obscure linkages, obscure substituent positions, and obscure reducing-end anomers as compatible with more specific motif fields in lenient mode.
- Preserves concrete mismatch rejection, including wrong linkage and wrong substituent-position cases.
- Enforces one-to-one substituent assignments so wildcard substituents cannot satisfy multiple motif requirements.
- Updates generated Rd documentation for the new argument and behavior.
- Adds regression tests for lenient linkages, reducing-end anomers, generic-to-concrete residue matching, substituent positions, one-to-one substituent assignments, and count/match wrappers.

## Verification

- `Rscript -e 'suppressMessages(devtools::test(filter = "have-motif"))'` -> 213 passed, 0 failed, 0 warnings.
- `Rscript -e 'suppressMessages(devtools::test())'` -> 522 passed, 0 failed, 0 warnings.
- `Rscript -e 'suppressMessages(devtools::check(error_on = "warning", document = FALSE))'` -> 0 errors, 0 warnings, 1 NOTE for system clock verification.
- `git diff --check` -> clean.

Closes #43