### PR TITLE
Require named optional motif arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `add_motifs_lgl()` and `add_motifs_int()` are deprecated. Use `dplyr::mutate()` or `glyexp::mutate_var()` with `tibble::as_tibble(have_motifs(...))` or `tibble::as_tibble(count_motifs(...))` instead. (#44)
 * Add `mode = "lenient"` to motif matching functions so lower-information glycans can match more specific motifs while concrete mismatches still fail. (#45)
+* Require optional arguments after the required inputs to be supplied by name in motif matching, graph matching, extraction, and viewing helpers. (#46)
 
 # glymotif 0.16.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `add_motifs_lgl()` and `add_motifs_int()` are deprecated. Use `dplyr::mutate()` or `glyexp::mutate_var()` with `tibble::as_tibble(have_motifs(...))` or `tibble::as_tibble(count_motifs(...))` instead. (#44)
 * Add `mode = "lenient"` to motif matching functions so lower-information glycans can match more specific motifs while concrete mismatches still fail. (#45)
-* Require optional arguments after the required inputs to be supplied by name in motif matching, graph matching, extraction, and viewing helpers. (#46)
+* Require optional arguments after the required inputs to be supplied by name in motif matching, graph matching, extraction, and viewing helpers. (#48)
 
 # glymotif 0.16.1
 

--- a/R/add-motifs.R
+++ b/R/add-motifs.R
@@ -158,10 +158,10 @@ add_motifs_lgl.glyexp_experiment <- function(
   motif_anno <- motif_anno_fn(
     exp$var_info$glycan_structure,
     motifs,
-    alignments,
-    ignore_linkages,
-    strict_sub,
-    match_degree
+    alignments = alignments,
+    ignore_linkages = ignore_linkages,
+    strict_sub = strict_sub,
+    match_degree = match_degree
   )
   # have_motifs/count_motifs set colnames for motif specs, but may return NULL for regular motifs
   # We always need colnames for add_motifs, so generate them if missing
@@ -247,10 +247,10 @@ add_motifs_lgl.data.frame <- function(
   motif_anno <- motif_anno_fn(
     df$glycan_structure,
     motifs,
-    alignments,
-    ignore_linkages,
-    strict_sub,
-    match_degree
+    alignments = alignments,
+    ignore_linkages = ignore_linkages,
+    strict_sub = strict_sub,
+    match_degree = match_degree
   )
   # have_motifs/count_motifs set colnames for motif specs, but may return NULL for regular motifs
   # We always need colnames for add_motifs, so generate them if missing

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -88,12 +88,15 @@
 count_motif <- function(
   glycans,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   # Store input names before processing
   glycan_names <- names(glycans)
 
@@ -122,12 +125,15 @@ count_motif <- function(
 count_motifs <- function(
   glycans,
   motifs,
+  ...,
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   params <- prepare_motif_args(
     glycans = glycans,
     motifs = motifs,

--- a/R/extract-motif.R
+++ b/R/extract-motif.R
@@ -22,6 +22,8 @@
 #' @param glycans One of:
 #'   - A [glyrepr::glycan_structure()] vector.
 #'   - A glycan structure string vector. All formats supported by [glyparse::auto_parse()] are accepted.
+#' @param ... These dots must be empty and are used only to force optional
+#'   arguments to be supplied by name.
 #' @param including_core A logical scalar. If `TRUE`, the N-glycan core structure
 #'   (`Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-` or `Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-`)
 #'   is appended to each branch motif. Default is `FALSE`.
@@ -44,7 +46,9 @@
 #' extract_branch_motif(glycans)
 #'
 #' @export
-extract_branch_motif <- function(glycans, including_core = FALSE) {
+extract_branch_motif <- function(glycans, ..., including_core = FALSE) {
+  rlang::check_dots_empty()
+
   checkmate::assert_flag(including_core)
   # 1. Handle input types and deduplicate
   glycans <- ensure_glycans_are_structures(glycans)
@@ -164,6 +168,8 @@ extract_branch_motif <- function(glycans, including_core = FALSE) {
 #' @param glycans One of:
 #'   - A [glyrepr::glycan_structure()] vector.
 #'   - A glycan structure string vector. All formats supported by [glyparse::auto_parse()] are accepted.
+#' @param ... These dots must be empty and are used only to force optional
+#'   arguments to be supplied by name.
 #' @param max_size The maximum number of monosaccharides in the extracted motifs. Default is 3.
 #'   Note that setting this value very large can be computationally expensive.
 #'   Try the default value first, and increase it progressively if needed.
@@ -176,7 +182,9 @@ extract_branch_motif <- function(glycans, including_core = FALSE) {
 #'
 #' @importFrom igraph V E induced_subgraph incident edge_attr neighbors
 #' @export
-extract_motif <- function(glycans, max_size = 3) {
+extract_motif <- function(glycans, ..., max_size = 3) {
+  rlang::check_dots_empty()
+
   glycans <- ensure_glycans_are_structures(glycans)
   glycans <- unique(glycans)
   structure_graphs <- glyrepr::get_structure_graphs(glycans, return_list = TRUE)

--- a/R/g-motif.R
+++ b/R/g-motif.R
@@ -7,6 +7,8 @@
 #'
 #' @param glycan_graph An igraph glycan graph.
 #' @param motif_graph An igraph motif graph.
+#' @param ... These dots must be empty and are used only to force optional
+#'   arguments to be supplied by name.
 #' @param alignment A character scalar: `"substructure"`, `"core"`,
 #'   `"terminal"`, or `"whole"`.
 #' @param ignore_linkages A logical scalar. If `TRUE`, linkages are ignored.
@@ -43,12 +45,15 @@ NULL
 .g_have_motif <- function(
   glycan_graph,
   motif_graph,
+  ...,
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
     motif_graph = motif_graph,
@@ -66,12 +71,15 @@ NULL
 .g_count_motif <- function(
   glycan_graph,
   motif_graph,
+  ...,
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
     motif_graph = motif_graph,
@@ -89,12 +97,15 @@ NULL
 .g_match_motif <- function(
   glycan_graph,
   motif_graph,
+  ...,
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
     motif_graph = motif_graph,

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -178,6 +178,8 @@
 #'   - A character vector of GGM database motif names
 #'     (use `db_motif_info() |> dplyr::filter(source_id == "GGM")`
 #'     to inspect resolvable motif names).
+#' @param ... These dots must be empty and are used only to force optional
+#'   arguments to be supplied by name.
 #' @param alignment A character string.
 #'   Possible values are "substructure", "core", "terminal", and "whole".
 #'   If not provided, the value will be decided based on the `motif` argument.
@@ -301,12 +303,15 @@
 have_motif <- function(
   glycans,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   # Store input names before processing
   glycan_names <- names(glycans)
 
@@ -335,12 +340,15 @@ have_motif <- function(
 have_motifs <- function(
   glycans,
   motifs,
+  ...,
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   params <- prepare_motif_args(
     glycans = glycans,
     motifs = motifs,

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -89,12 +89,15 @@
 match_motif <- function(
   glycans,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   # Store input names before processing
   glycan_names <- names(glycans)
 
@@ -125,12 +128,15 @@ match_motif <- function(
 match_motifs <- function(
   glycans,
   motifs,
+  ...,
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
   mode = c("strict", "lenient")
 ) {
+  rlang::check_dots_empty()
+
   # Validate glycans first (must be glycan_structure)
   .assert_glycan_structure(glycans, "glycans")
 

--- a/R/view-motifs.R
+++ b/R/view-motifs.R
@@ -32,11 +32,14 @@
 view_motif <- function(
   glycan,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL
 ) {
+  rlang::check_dots_empty()
+
   if (length(glycan) != 1) {
     cli::cli_abort(c(
       "Only one glycan can be visualized at a time.",
@@ -62,7 +65,7 @@ view_motif <- function(
   match_res <- match_motif(
     params$glycans,
     params$motif,
-    params$alignment,
+    alignment = params$alignment,
     ignore_linkages = params$ignore_linkages,
     strict_sub = params$strict_sub,
     match_degree = params$match_degree

--- a/man/count_motif.Rd
+++ b/man/count_motif.Rd
@@ -8,6 +8,7 @@
 count_motif(
   glycans,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -18,6 +19,7 @@ count_motif(
 count_motifs(
   glycans,
   motifs,
+  ...,
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -40,6 +42,9 @@ including IUPAC-condensed, WURCS, GlycoCT, and others.
 \item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
 to inspect resolvable motif names).
 }}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{alignment}{A character string.
 Possible values are "substructure", "core", "terminal", and "whole".

--- a/man/dot-g_motif.Rd
+++ b/man/dot-g_motif.Rd
@@ -10,6 +10,7 @@
 .g_have_motif(
   glycan_graph,
   motif_graph,
+  ...,
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -20,6 +21,7 @@
 .g_count_motif(
   glycan_graph,
   motif_graph,
+  ...,
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -30,6 +32,7 @@
 .g_match_motif(
   glycan_graph,
   motif_graph,
+  ...,
   alignment = "substructure",
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -41,6 +44,9 @@
 \item{glycan_graph}{An igraph glycan graph.}
 
 \item{motif_graph}{An igraph motif graph.}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{alignment}{A character scalar: \code{"substructure"}, \code{"core"},
 \code{"terminal"}, or \code{"whole"}.}

--- a/man/extract_branch_motif.Rd
+++ b/man/extract_branch_motif.Rd
@@ -4,7 +4,7 @@
 \alias{extract_branch_motif}
 \title{Extract Branch Motifs}
 \usage{
-extract_branch_motif(glycans, including_core = FALSE)
+extract_branch_motif(glycans, ..., including_core = FALSE)
 }
 \arguments{
 \item{glycans}{One of:
@@ -12,6 +12,9 @@ extract_branch_motif(glycans, including_core = FALSE)
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
 \item A glycan structure string vector. All formats supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}} are accepted.
 }}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{including_core}{A logical scalar. If \code{TRUE}, the N-glycan core structure
 (\verb{Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-} or \verb{Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-})

--- a/man/extract_motif.Rd
+++ b/man/extract_motif.Rd
@@ -4,7 +4,7 @@
 \alias{extract_motif}
 \title{Extract All Substructures (Motifs)}
 \usage{
-extract_motif(glycans, max_size = 3)
+extract_motif(glycans, ..., max_size = 3)
 }
 \arguments{
 \item{glycans}{One of:
@@ -12,6 +12,9 @@ extract_motif(glycans, max_size = 3)
 \item A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
 \item A glycan structure string vector. All formats supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}} are accepted.
 }}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{max_size}{The maximum number of monosaccharides in the extracted motifs. Default is 3.
 Note that setting this value very large can be computationally expensive.

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -8,6 +8,7 @@
 have_motif(
   glycans,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -18,6 +19,7 @@ have_motif(
 have_motifs(
   glycans,
   motifs,
+  ...,
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -40,6 +42,9 @@ including IUPAC-condensed, WURCS, GlycoCT, and others.
 \item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
 to inspect resolvable motif names).
 }}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{alignment}{A character string.
 Possible values are "substructure", "core", "terminal", and "whole".

--- a/man/match_motif.Rd
+++ b/man/match_motif.Rd
@@ -8,6 +8,7 @@
 match_motif(
   glycans,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -18,6 +19,7 @@ match_motif(
 match_motifs(
   glycans,
   motifs,
+  ...,
   alignments = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -40,6 +42,9 @@ including IUPAC-condensed, WURCS, GlycoCT, and others.
 \item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
 to inspect resolvable motif names).
 }}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{alignment}{A character string.
 Possible values are "substructure", "core", "terminal", and "whole".

--- a/man/view_motif.Rd
+++ b/man/view_motif.Rd
@@ -7,6 +7,7 @@
 view_motif(
   glycan,
   motif,
+  ...,
   alignment = NULL,
   ignore_linkages = FALSE,
   strict_sub = TRUE,
@@ -28,6 +29,9 @@ are accepted, including IUPAC-condensed, WURCS, GlycoCT, and others.
 \item A GGM database motif name (use \code{db_motif_info() |> dplyr::filter(source_id == "GGM")}
 to inspect resolvable motif names).
 }}
+
+\item{...}{These dots must be empty and are used only to force optional
+arguments to be supplied by name.}
 
 \item{alignment}{A character string.
 Possible values are "substructure", "core", "terminal", and "whole".

--- a/tests/testthat/test-count-motif.R
+++ b/tests/testthat/test-count-motif.R
@@ -4,6 +4,17 @@ test_that("count motifs in glycan", {
   expect_equal(count_motif(glycan, motif), 2L)
 })
 
+test_that("optional count_motif arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motif <- "Gal(b1-3)GalNAc(a1-"
+
+  expect_error(
+    count_motif(glycan, motif, "whole"),
+    "must be empty"
+  )
+  expect_equal(count_motif(glycan, motif, alignment = "whole"), 1L)
+})
+
 
 test_that("count_motif supports multiple glycan structure formats", {
   # Test IUPAC-condensed format
@@ -60,6 +71,20 @@ test_that("count_motifs works with multiple motifs", {
   expect_equal(as.integer(result[1, 2]), 2L) # Gal(b1-
   expect_equal(as.integer(result[2, 1]), 1L) # Gal(b1-3)GalNAc(b1-
   expect_equal(as.integer(result[2, 2]), 1L) # Gal(b1-
+})
+
+test_that("optional count_motifs arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motifs <- c("Gal(b1-3)GalNAc(a1-", "Gal(b1-")
+
+  expect_error(
+    count_motifs(glycan, motifs, "whole"),
+    "must be empty"
+  )
+
+  result <- count_motifs(glycan, motifs, alignments = "whole")
+  expect_true(is.matrix(result))
+  expect_equal(ncol(result), 2L)
 })
 
 

--- a/tests/testthat/test-extract-motif.R
+++ b/tests/testthat/test-extract-motif.R
@@ -56,6 +56,16 @@ test_that("extract_motif's max_size works", {
   expect_setequal(as.character(result), as.character(expected))
 })
 
+test_that("optional extract_motif arguments must be named", {
+  glycan <- "Gal(b1-3)GalNAc(a1-"
+
+  expect_error(
+    extract_motif(glycan, 2),
+    "must be empty"
+  )
+  expect_no_error(extract_motif(glycan, max_size = 2))
+})
+
 test_that("extract_branch_motif works for intact glycan structures", {
   glycan <- "Neu5Ac(a2-3)Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Gal(b1-4)GlcNAc(b1-2)Man(a1-6)]Man(b1-4)GlcNAc(a1-4)GlcNAc(b1-"
   res <- extract_branch_motif(glycan)
@@ -125,6 +135,16 @@ test_that("extract_branch_motif works for glycans with complex branching pattern
 test_that("extract_branch_motif rejects glycans other than N-glycans", {
   glycan <- "Gal(b1-3)GalNAc(a1-"
   expect_error(extract_branch_motif(glycan), "must be N-glycans")
+})
+
+test_that("optional extract_branch_motif arguments must be named", {
+  glycan <- glyrepr::n_glycan_core()
+
+  expect_error(
+    extract_branch_motif(glycan, TRUE),
+    "must be empty"
+  )
+  expect_no_error(extract_branch_motif(glycan, including_core = TRUE))
 })
 
 test_that("extract_branch_motif with including_core works for topological glycans", {

--- a/tests/testthat/test-g-motif.R
+++ b/tests/testthat/test-g-motif.R
@@ -40,6 +40,36 @@ test_that(".g_* motif functions support matching options", {
   )
 })
 
+test_that("optional .g_* motif arguments must be named", {
+  glycan <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  motif <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+
+  expect_error(
+    .g_have_motif(glycan_graph, motif_graph, "whole"),
+    "must be empty"
+  )
+  expect_error(
+    .g_count_motif(glycan_graph, motif_graph, "whole"),
+    "must be empty"
+  )
+  expect_error(
+    .g_match_motif(glycan_graph, motif_graph, "whole"),
+    "must be empty"
+  )
+
+  expect_true(.g_have_motif(glycan_graph, motif_graph, alignment = "whole"))
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, alignment = "whole"),
+    1L
+  )
+  expect_equal(
+    .g_match_motif(glycan_graph, motif_graph, alignment = "whole"),
+    list(c(1L, 2L))
+  )
+})
+
 test_that(".g_* motif functions keep mono-type compatibility as caller contract", {
   glycan <- glyrepr::as_glycan_structure("Man(?1-")
   generic_motif <- glyrepr::as_glycan_structure("Hex(?1-")

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -147,6 +147,31 @@ test_that("warning when user-provided alignment is different from database", {
   expect_false(result)
 })
 
+test_that("optional have_motif arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motif <- "Gal(b1-3)GalNAc(a1-"
+
+  expect_error(
+    have_motif(glycan, motif, "whole"),
+    "must be empty"
+  )
+  expect_true(have_motif(glycan, motif, alignment = "whole"))
+})
+
+test_that("optional have_motifs arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motifs <- c("Gal(b1-3)GalNAc(a1-", "Gal(b1-")
+
+  expect_error(
+    have_motifs(glycan, motifs, "whole"),
+    "must be empty"
+  )
+
+  result <- have_motifs(glycan, motifs, alignments = "whole")
+  expect_true(is.matrix(result))
+  expect_equal(ncol(result), 2L)
+})
+
 
 # ========== Monosaccharide Types ==========
 test_that("concrete glycan and generic motif", {

--- a/tests/testthat/test-match-motif.R
+++ b/tests/testthat/test-match-motif.R
@@ -39,6 +39,19 @@ test_that("match_motif works", {
   expect_match_motif_equal(result, list(list(c(1, 2, 3))))
 })
 
+test_that("optional match_motif arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(a1-")
+
+  expect_error(
+    match_motif(glycan, motif, "whole"),
+    "must be empty"
+  )
+
+  result <- match_motif(glycan, motif, alignment = "whole")
+  expect_match_motif_equal(result, list(list(c(1, 2))))
+})
+
 test_that("match_motif rejects non-glyrepr_structure objects", {
   glycan <- glyrepr::n_glycan_core()
   motif <- "Man(a1-3)[Man(a1-6)]Man(b1-"
@@ -78,6 +91,23 @@ test_that("match_motifs works", {
     list(list(c(1, 3, 4, 5), c(2, 3, 4, 5)))
   )
   expect_match_motifs_equal(result, expected)
+})
+
+test_that("optional match_motifs arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motifs <- glyparse::parse_iupac_condensed(c(
+    "Gal(b1-3)GalNAc(a1-",
+    "Gal(b1-"
+  ))
+
+  expect_error(
+    match_motifs(glycan, motifs, "whole"),
+    "must be empty"
+  )
+
+  result <- match_motifs(glycan, motifs, alignments = "whole")
+  expect_type(result, "list")
+  expect_length(result, 2L)
 })
 
 test_that("match_motifs accepts character vectors and parses them", {

--- a/tests/testthat/test-view-motifs.R
+++ b/tests/testthat/test-view-motifs.R
@@ -18,6 +18,20 @@ test_that("view_motif accepts structure strings", {
   expect_s3_class(result, "ggplot")
 })
 
+test_that("optional view_motif arguments must be named", {
+  glycan <- glyrepr::o_glycan_core_1()
+  motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(a1-")
+
+  expect_error(
+    view_motif(glycan, motif, "whole"),
+    "must be empty"
+  )
+
+  result <- suppressMessages(view_motif(glycan, motif, alignment = "whole"))
+  expect_s3_class(result, "glydraw_cartoon")
+  expect_s3_class(result, "ggplot")
+})
+
 test_that("view_motif returns an unhighlighted plot when no match is found", {
   glycan <- glyrepr::n_glycan_core()
   motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(a1-")

--- a/vignettes/motif-matching.Rmd
+++ b/vignettes/motif-matching.Rmd
@@ -315,7 +315,7 @@ motifs <- c(
            "Gal(a1-4)Gal(a1-"            # motif 4: internal fragment
 )
 alignments <- c("substructure", "whole", "core", "terminal")
-mat <- do.call(cbind, purrr::map(alignments, ~ have_motifs_simple(glycan, motifs, alignment = .x)))
+mat <- do.call(cbind, purrr::map(alignments, ~ have_motifs_simple(glycan, motifs, alignments = .x)))
 colnames(mat) <- alignments
 rownames(mat) <- paste0("motif_", 1:4)
 mat


### PR DESCRIPTION
## Summary

Require optional arguments after the required glycan, motif, graph, extraction, and viewing inputs to be supplied by name.

## Rational

Issue #46 asks for `...` between required and optional arguments so calls like `have_motif(glycan, motif, "core")` fail, while explicit calls like `have_motif(glycan, motif, alignment = "core")` continue to work. This makes optional matching behavior clearer at call sites and avoids accidental positional argument use.

## Details

- Added empty `...` checks to active motif matching helpers: `have_motif()`, `have_motifs()`, `count_motif()`, `count_motifs()`, `match_motif()`, and `match_motifs()`.
- Applied the same keyword-only contract to graph-level helpers, motif extraction helpers, and `view_motif()`.
- Kept deprecated `add_motifs_lgl()` and `add_motifs_int()` public signatures unchanged, while updating their internal calls to forward into the active plural helpers with named optional arguments.
- Updated Rd documentation, regression tests, and the NEWS entry for PR #48.
- Fixed the motif-matching vignette to use `alignments =` for the plural helper after `devtools::check()` exposed the mismatch.

## Verification

- `Rscript -e 'devtools::test(filter = "add-motifs|have-motif|count-motif|match-motif|g-motif|extract-motif|view-motifs")'` passed with 452 assertions.
- `Rscript -e 'devtools::check()'` completed with 0 errors, 0 warnings, and 1 NOTE for system-clock verification in the sandbox.
- `Rscript -e 'devtools::load_all(); df <- tibble::tibble(glycan_structure = c(glyrepr::o_glycan_core_1(), glyrepr::o_glycan_core_2())); motifs <- c("O-Glycan core 1", "O-Glycan core 2"); suppressWarnings(add_motifs_lgl(df, motifs, c("whole", "whole"))); suppressWarnings(add_motifs_int(df, motifs, c("whole", "whole")))'` confirmed deprecated positional add-motifs calls still work.
- `Rscript -e 'devtools::test()'` passed with 550 assertions after the final NEWS update.
- `air format .`
- `git diff --check`

Closes #46