### PR TITLE
Recommend Stage II row-based glyexp workflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Suggests:
     patrick,
     knitr,
     rmarkdown,
-    glyexp (>= 0.12.4)
+    glyexp (>= 0.16.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glymotif (development version)
 
-* Documentation now recommends `GlycomicSE` and `GlycoproteomicSE` containers and the `mutate_row()` replacement for deprecated motif-annotation helpers as part of Stage II of glycoverse/glyexp#15.
+* Documentation now recommends `GlycomicSE` and `GlycoproteomicSE` containers and the `mutate_row()` replacement for deprecated motif-annotation helpers as part of Stage II of glycoverse/glyexp#15. (#49)
 
 # glymotif 0.17.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glymotif (development version)
 
+* Documentation now recommends `GlycomicSE` and `GlycoproteomicSE` containers and the `mutate_row()` replacement for deprecated motif-annotation helpers as part of Stage II of glycoverse/glyexp#15.
+
 # glymotif 0.17.1
 
 * Examples for `add_motifs_int()` now run with both legacy and current `glyexp` containers and use valid condensed IUPAC glycans.

--- a/R/add-motifs.R
+++ b/R/add-motifs.R
@@ -5,8 +5,10 @@
 #'
 #' `add_motifs_int()` and `add_motifs_lgl()` were deprecated in glymotif
 #' 0.17.0. For data frames, use [dplyr::mutate()] with [tibble::as_tibble()]
-#' and [count_motifs()] or [have_motifs()]. For [glyexp::experiment()]
-#' objects, use [glyexp::mutate_var()] with the same tibble expression.
+#' and [count_motifs()] or [have_motifs()]. For [glyexp::GlycomicSE()] or
+#' [glyexp::GlycoproteomicSE()] objects, use [glyexp::mutate_row()] with the
+#' same tibble expression. The deprecated methods for legacy glyexp containers
+#' remain available for compatibility.
 #'
 #' @section About Names:
 #'
@@ -26,30 +28,26 @@
 #' motifs. The functions here always provide column names since they are designed
 #' for adding motif annotations to data frames.
 #'
-#' @param x A [glyexp::experiment()] object, or a tibble with a structure column.
+#' @param x A legacy glyexp data container or a tibble with a structure column.
 #' @param ... Additional arguments passed to the method.
 #' @inheritParams have_motifs
 #'
-#' @return An [glyexp::experiment()] object with motif annotations added to the variable information.
+#' @return The legacy glyexp data container or data frame supplied in `x`, with
+#'   motif annotations added to its variable information.
 #'
 #' @examples
 #' library(glyexp)
 #' library(dplyr)
 #' library(tibble)
 #'
-#' exp <- real_experiment2
+#' glyco_se <- real_experiment2
 #' motifs <- c(
 #'   lacnac = "Gal(??-?)GlcNAc(??-",
 #'   sia_lacnac = "Neu5Ac(??-?)Gal(??-?)GlcNAc(??-"
 #' )
 #'
-#' if (inherits(exp, "glyexp_experiment")) {
-#'   exp |>
-#'     mutate_var(as_tibble(have_motifs(glycan_structure, motifs)))
-#' } else {
-#'   exp |>
-#'     mutate_row(as_tibble(have_motifs(glycan_structure, motifs)))
-#' }
+#' glyco_se |>
+#'   mutate_row(as_tibble(count_motifs(glycan_structure, motifs)))
 #'
 #' df <- tibble(
 #'   glycan_structure = c(
@@ -60,7 +58,8 @@
 #' df |>
 #'   mutate(as_tibble(count_motifs(glycan_structure, motifs)))
 #'
-#' @seealso [glymotif::have_motifs()], [glymotif::count_motifs()], [glyexp::experiment()]
+#' @seealso [glymotif::have_motifs()], [glymotif::count_motifs()],
+#'   [glyexp::GlycomicSE()], [glyexp::GlycoproteomicSE()]
 #'
 #' @export
 add_motifs_int <- function(
@@ -77,7 +76,7 @@ add_motifs_int <- function(
     "add_motifs_int()",
     details = c(
       "For data frames, use `dplyr::mutate(as_tibble(count_motifs(glycan_structure, motifs)))`.",
-      "For glyexp experiments, use `glyexp::mutate_var(as_tibble(count_motifs(glycan_structure, motifs)))`."
+      "For glyexp containers, use `glyexp::mutate_row(as_tibble(count_motifs(glycan_structure, motifs)))`."
     )
   )
   UseMethod("add_motifs_int")
@@ -99,7 +98,7 @@ add_motifs_lgl <- function(
     "add_motifs_lgl()",
     details = c(
       "For data frames, use `dplyr::mutate(as_tibble(have_motifs(glycan_structure, motifs)))`.",
-      "For glyexp experiments, use `glyexp::mutate_var(as_tibble(have_motifs(glycan_structure, motifs)))`."
+      "For glyexp containers, use `glyexp::mutate_row(as_tibble(have_motifs(glycan_structure, motifs)))`."
     )
   )
   UseMethod("add_motifs_lgl")

--- a/man/add_motifs_int.Rd
+++ b/man/add_motifs_int.Rd
@@ -70,7 +70,7 @@ add_motifs_lgl(
 )
 }
 \arguments{
-\item{x}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} object, or a tibble with a structure column.}
+\item{x}{A legacy glyexp data container or a tibble with a structure column.}
 
 \item{motifs}{One of:
 \itemize{
@@ -102,15 +102,18 @@ provided, \code{alignment} and \code{alignments} are silently ignored.}
 \item{...}{Additional arguments passed to the method.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object with motif annotations added to the variable information.
+The legacy glyexp data container or data frame supplied in \code{x}, with
+motif annotations added to its variable information.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 \code{add_motifs_int()} and \code{add_motifs_lgl()} were deprecated in glymotif
 0.17.0. For data frames, use \code{\link[dplyr:mutate]{dplyr::mutate()}} with \code{\link[tibble:as_tibble]{tibble::as_tibble()}}
-and \code{\link[=count_motifs]{count_motifs()}} or \code{\link[=have_motifs]{have_motifs()}}. For \code{\link[glyexp:experiment]{glyexp::experiment()}}
-objects, use \code{\link[glyexp:mutate_obs]{glyexp::mutate_var()}} with the same tibble expression.
+and \code{\link[=count_motifs]{count_motifs()}} or \code{\link[=have_motifs]{have_motifs()}}. For \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} objects, use \code{\link[glyexp:mutate_col]{glyexp::mutate_row()}} with the
+same tibble expression. The deprecated methods for legacy glyexp containers
+remain available for compatibility.
 }
 \section{About Names}{
 
@@ -139,19 +142,14 @@ library(glyexp)
 library(dplyr)
 library(tibble)
 
-exp <- real_experiment2
+glyco_se <- real_experiment2
 motifs <- c(
   lacnac = "Gal(??-?)GlcNAc(??-",
   sia_lacnac = "Neu5Ac(??-?)Gal(??-?)GlcNAc(??-"
 )
 
-if (inherits(exp, "glyexp_experiment")) {
-  exp |>
-    mutate_var(as_tibble(have_motifs(glycan_structure, motifs)))
-} else {
-  exp |>
-    mutate_row(as_tibble(have_motifs(glycan_structure, motifs)))
-}
+glyco_se |>
+  mutate_row(as_tibble(count_motifs(glycan_structure, motifs)))
 
 df <- tibble(
   glycan_structure = c(
@@ -164,5 +162,6 @@ df |>
 
 }
 \seealso{
-\code{\link[=have_motifs]{have_motifs()}}, \code{\link[=count_motifs]{count_motifs()}}, \code{\link[glyexp:experiment]{glyexp::experiment()}}
+\code{\link[=have_motifs]{have_motifs()}}, \code{\link[=count_motifs]{count_motifs()}},
+\code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}
 }

--- a/vignettes/glymotif.Rmd
+++ b/vignettes/glymotif.Rmd
@@ -361,7 +361,8 @@ Functions supporting `dynamic_motifs()` and `branch_motifs()`:
 ## What's Next?
 
 - Want more detail about motif matching rules? See [Motif Matching Rules](https://glycoverse.github.io/glymotif/articles/motif-matching.html).
-- Working with `glyexp::experiment()`? See [Working with glyexp](https://glycoverse.github.io/glymotif/articles/with-exp.html).
+- Working with `GlycomicSE` or `GlycoproteomicSE`? See
+  [Creating a Glyco SummarizedExperiment](https://glycoverse.github.io/glyexp/articles/create-exp.html).
 
 ## Related Projects
 


### PR DESCRIPTION
Part of glycoverse/glyexp#15.

## Summary
- Recommend `GlycomicSE` and `GlycoproteomicSE` in motif-annotation documentation.
- Point deprecated motif-annotation helpers to the current `mutate_row()` workflow while retaining legacy methods.
- Require `glyexp >= 0.16.0`.

## Verification
- `devtools::check()` — 0 errors, 0 warnings, 0 notes.
- Verified no standalone legacy `experiment()` constructor calls remain in public documentation.