### PR TITLE
perf: accelerate batch motif analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # glymotif (development version)
 
-* `have_motifs()`, `count_motifs()`, and `match_motifs()` now reuse graph metadata across batch matching, substantially reducing runtime for many-glycan, many-motif analyses.
+* `have_motifs()`, `count_motifs()`, and `match_motifs()` now reuse graph metadata across batch matching, substantially reducing runtime for many-glycan, many-motif analyses. (#50)
 
-* `extract_motif()` now discards duplicate candidates before constructing subgraphs, substantially reducing dynamic-motif extraction time.
+* `extract_motif()` now discards duplicate candidates before constructing subgraphs, substantially reducing dynamic-motif extraction time. (#50)
 
-* Lenient motif matching now uses conservative generic-residue filters to avoid unnecessary graph searches while preserving fuzzy-modification matching.
+* Lenient motif matching now uses conservative generic-residue filters to avoid unnecessary graph searches while preserving fuzzy-modification matching. (#50)
 
 # glymotif 0.17.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glymotif (development version)
 
+* `have_motifs()`, `count_motifs()`, and `match_motifs()` now reuse graph metadata across batch matching, substantially reducing runtime for many-glycan, many-motif analyses.
+
 # glymotif 0.17.2
 
 * Documentation now recommends `GlycomicSE` and `GlycoproteomicSE` containers and the `mutate_row()` replacement for deprecated motif-annotation helpers as part of Stage II of glycoverse/glyexp#15. (#49)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `have_motifs()`, `count_motifs()`, and `match_motifs()` now reuse graph metadata across batch matching, substantially reducing runtime for many-glycan, many-motif analyses.
 
+* `extract_motif()` now discards duplicate candidates before constructing subgraphs, substantially reducing dynamic-motif extraction time.
+
 # glymotif 0.17.2
 
 * Documentation now recommends `GlycomicSE` and `GlycoproteomicSE` containers and the `mutate_row()` replacement for deprecated motif-annotation helpers as part of Stage II of glycoverse/glyexp#15. (#49)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `extract_motif()` now discards duplicate candidates before constructing subgraphs, substantially reducing dynamic-motif extraction time.
 
+* Lenient motif matching now uses conservative generic-residue filters to avoid unnecessary graph searches while preserving fuzzy-modification matching.
+
 # glymotif 0.17.2
 
 * Documentation now recommends `GlycomicSE` and `GlycoproteomicSE` containers and the `mutate_row()` replacement for deprecated motif-annotation helpers as part of Stage II of glycoverse/glyexp#15. (#49)

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -5,19 +5,26 @@ colorize_graphs <- function(
   glycan_batch_profile = NULL,
   motif_batch_profile = NULL
 ) {
-  if (mode == "lenient") {
-    return(list(glycan_colors = NULL, motif_colors = NULL))
-  }
-
   if (!is.null(glycan_batch_profile) && !is.null(motif_batch_profile)) {
-    color_type <- if (motif_batch_profile$use_base_keys) {
-      "base_colors"
-    } else {
-      "exact_colors"
+    key_mode <- motif_batch_profile$key_mode
+    if (key_mode == "none") {
+      return(list(glycan_colors = NULL, motif_colors = NULL))
+    }
+    if (key_mode == "exact") {
+      return(list(
+        glycan_colors = glycan_batch_profile$exact_colors,
+        motif_colors = motif_batch_profile$exact_colors
+      ))
+    }
+    if (key_mode == "base") {
+      return(list(
+        glycan_colors = glycan_batch_profile$base_colors,
+        motif_colors = motif_batch_profile$base_colors
+      ))
     }
     return(list(
-      glycan_colors = glycan_batch_profile[[color_type]],
-      motif_colors = motif_batch_profile[[color_type]]
+      glycan_colors = glycan_batch_profile$generic_colors,
+      motif_colors = motif_batch_profile$generic_colors
     ))
   }
 
@@ -25,10 +32,12 @@ colorize_graphs <- function(
   # mutating the input graphs.
   glycan_monos <- igraph::V(glycan)$mono
   motif_monos <- igraph::V(motif)$mono
-  if (has_fuzzy_modification(motif)) {
-    glycan_monos <- residue_color_keys(glycan_monos)
-    motif_monos <- residue_color_keys(motif_monos)
+  key_mode <- resolve_residue_key_mode(motif, mode)
+  if (key_mode == "none") {
+    return(list(glycan_colors = NULL, motif_colors = NULL))
   }
+  glycan_monos <- residue_match_keys(glycan_monos, key_mode)
+  motif_monos <- residue_match_keys(motif_monos, key_mode)
 
   unique_monos <- unique(c(glycan_monos, motif_monos))
   color_map <- seq_along(unique_monos)
@@ -43,22 +52,30 @@ colorize_graphs <- function(
 #' Create a Motif Composition Profile
 #'
 #' @param motif A motif graph.
+#' @param mode Matching mode.
 #'
 #' @return A list containing residue keys, required counts, and keying mode.
 #' @noRd
-new_motif_composition_profile <- function(motif) {
-  use_base_keys <- has_fuzzy_modification(motif)
-  motif_monos <- igraph::vertex_attr(motif, "mono")
-  if (use_base_keys) {
-    motif_monos <- residue_color_keys(motif_monos)
+new_motif_composition_profile <- function(motif, mode = "strict") {
+  key_mode <- resolve_residue_key_mode(motif, mode)
+  if (key_mode == "none") {
+    return(list(
+      keys = character(),
+      counts = integer(),
+      key_mode = key_mode
+    ))
   }
 
+  motif_monos <- residue_match_keys(
+    igraph::vertex_attr(motif, "mono"),
+    key_mode
+  )
   keys <- unique(motif_monos)
   counts <- tabulate(match(motif_monos, keys), nbins = length(keys))
   list(
     keys = keys,
     counts = counts,
-    use_base_keys = use_base_keys
+    key_mode = key_mode
   )
 }
 
@@ -78,27 +95,79 @@ composition_can_match <- function(
   glycan_batch_profile = NULL,
   motif_batch_profile = NULL
 ) {
+  key_mode <- motif_profile$key_mode
+  if (key_mode == "none") {
+    return(TRUE)
+  }
+
   if (!is.null(glycan_batch_profile) && !is.null(motif_batch_profile)) {
-    count_type <- if (motif_profile$use_base_keys) {
-      "base_counts"
-    } else {
-      "exact_counts"
+    if (key_mode == "exact") {
+      return(all(
+        glycan_batch_profile$exact_counts >= motif_batch_profile$exact_counts
+      ))
+    }
+    if (key_mode == "base") {
+      return(all(
+        glycan_batch_profile$base_counts >= motif_batch_profile$base_counts
+      ))
     }
     return(all(
-      glycan_batch_profile[[count_type]] >= motif_batch_profile[[count_type]]
+      glycan_batch_profile$generic_counts >= motif_batch_profile$generic_counts
     ))
   }
 
-  glycan_monos <- igraph::vertex_attr(glycan, "mono")
-  if (motif_profile$use_base_keys) {
-    glycan_monos <- residue_color_keys(glycan_monos)
-  }
+  glycan_monos <- residue_match_keys(
+    igraph::vertex_attr(glycan, "mono"),
+    key_mode
+  )
 
   glycan_counts <- tabulate(
     match(glycan_monos, motif_profile$keys),
     nbins = length(motif_profile$keys)
   )
   all(glycan_counts >= motif_profile$counts)
+}
+
+
+#' Resolve Residue Keys for Conservative VF2 Pruning
+#'
+#' @param motif A motif graph.
+#' @param mode Matching mode.
+#'
+#' @return One of `"exact"`, `"base"`, `"generic"`, or `"none"`.
+#' @noRd
+resolve_residue_key_mode <- function(motif, mode = "strict") {
+  fuzzy <- has_fuzzy_modification(motif)
+  if (mode == "lenient") {
+    if (fuzzy) {
+      return("none")
+    }
+    return("generic")
+  }
+
+  if (fuzzy) {
+    "base"
+  } else {
+    "exact"
+  }
+}
+
+
+#' Create Residue Keys for Conservative VF2 Pruning
+#'
+#' @param monos A character vector of monosaccharide names from one graph.
+#' @param key_mode The residue keying mode.
+#'
+#' @return A character vector of residue keys.
+#' @noRd
+residue_match_keys <- function(monos, key_mode) {
+  switch(
+    key_mode,
+    exact = monos,
+    base = residue_color_keys(monos),
+    generic = glyrepr::convert_to_generic(monos),
+    none = character()
+  )
 }
 
 

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -1,6 +1,24 @@
-colorize_graphs <- function(glycan, motif, mode = "strict") {
+colorize_graphs <- function(
+  glycan,
+  motif,
+  mode = "strict",
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
+) {
   if (mode == "lenient") {
     return(list(glycan_colors = NULL, motif_colors = NULL))
+  }
+
+  if (!is.null(glycan_batch_profile) && !is.null(motif_batch_profile)) {
+    color_type <- if (motif_batch_profile$use_base_keys) {
+      "base_colors"
+    } else {
+      "exact_colors"
+    }
+    return(list(
+      glycan_colors = glycan_batch_profile[[color_type]],
+      motif_colors = motif_batch_profile[[color_type]]
+    ))
   }
 
   # Prepare VF2 color vectors from the "mono" vertex attributes without
@@ -54,7 +72,23 @@ new_motif_composition_profile <- function(motif) {
 #'
 #' @return A logical scalar.
 #' @noRd
-composition_can_match <- function(glycan, motif_profile) {
+composition_can_match <- function(
+  glycan,
+  motif_profile,
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
+) {
+  if (!is.null(glycan_batch_profile) && !is.null(motif_batch_profile)) {
+    count_type <- if (motif_profile$use_base_keys) {
+      "base_counts"
+    } else {
+      "exact_counts"
+    }
+    return(all(
+      glycan_batch_profile[[count_type]] >= motif_batch_profile[[count_type]]
+    ))
+  }
+
   glycan_monos <- igraph::vertex_attr(glycan, "mono")
   if (motif_profile$use_base_keys) {
     glycan_monos <- residue_color_keys(glycan_monos)
@@ -76,9 +110,22 @@ composition_can_match <- function(glycan, motif_profile) {
 #'
 #' @return A logical scalar.
 #' @noRd
-whole_alignment_size_can_match <- function(glycan, motif, alignment) {
+whole_alignment_size_can_match <- function(
+  glycan,
+  motif,
+  alignment,
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
+) {
   if (alignment != "whole") {
     return(TRUE)
+  }
+
+  if (!is.null(glycan_batch_profile) && !is.null(motif_batch_profile)) {
+    return(
+      glycan_batch_profile$vcount == motif_batch_profile$vcount &&
+        glycan_batch_profile$ecount == motif_batch_profile$ecount
+    )
   }
 
   igraph::vcount(glycan) == igraph::vcount(motif) &&
@@ -103,20 +150,35 @@ core_alignment_root_can_match <- function(
   motif,
   alignment,
   strict_sub,
-  mode = "strict"
+  mode = "strict",
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
 ) {
   if (alignment != "core") {
     return(TRUE)
   }
 
-  glycan_core <- core_node(glycan)
-  motif_core <- core_node(motif)
+  if (!is.null(glycan_batch_profile) && !is.null(motif_batch_profile)) {
+    glycan_core <- glycan_batch_profile$core
+    motif_core <- motif_batch_profile$core
+    glycan_mono <- glycan_batch_profile$monos[[glycan_core]]
+    glycan_sub <- glycan_batch_profile$subs[[glycan_core]]
+    motif_mono <- motif_batch_profile$monos[[motif_core]]
+    motif_sub <- motif_batch_profile$subs[[motif_core]]
+  } else {
+    glycan_core <- core_node(glycan)
+    motif_core <- core_node(motif)
+    glycan_mono <- igraph::vertex_attr(glycan, "mono", index = glycan_core)
+    glycan_sub <- igraph::vertex_attr(glycan, "sub", index = glycan_core)
+    motif_mono <- igraph::vertex_attr(motif, "mono", index = motif_core)
+    motif_sub <- igraph::vertex_attr(motif, "sub", index = motif_core)
+  }
 
   match_residue(
-    igraph::vertex_attr(glycan, "mono", index = glycan_core),
-    igraph::vertex_attr(glycan, "sub", index = glycan_core),
-    igraph::vertex_attr(motif, "mono", index = motif_core),
-    igraph::vertex_attr(motif, "sub", index = motif_core),
+    glycan_mono,
+    glycan_sub,
+    motif_mono,
+    motif_sub,
     strict_sub = strict_sub,
     mode = mode
   )
@@ -492,7 +554,8 @@ resolve_linkage_match_mode <- function(
   glycan,
   motif_has_linkages,
   ignore_linkages,
-  mode = "strict"
+  mode = "strict",
+  glycan_batch_profile = NULL
 ) {
   # Unlinked motifs are linkage-agnostic: once mono/sub/alignment checks pass,
   # wildcard linkage checks cannot reject additional candidates.
@@ -502,7 +565,12 @@ resolve_linkage_match_mode <- function(
 
   # A linked motif cannot match an unlinked glycan. Returning "none" lets callers
   # bypass VF2 entirely and return the empty result for their output type.
-  if (mode == "strict" && !graph_has_linkages(glycan)) {
+  glycan_has_linkages <- if (is.null(glycan_batch_profile)) {
+    graph_has_linkages(glycan)
+  } else {
+    glycan_batch_profile$has_linkages
+  }
+  if (mode == "strict" && !glycan_has_linkages) {
     return("none")
   }
 

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -206,10 +206,20 @@ count_motif_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
 ) {
   # This function is the logic part of `count_motif()`.
-  if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
+  if (
+    !whole_alignment_size_can_match(
+      glycan_graph,
+      motif_graph,
+      alignment,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
+    )
+  ) {
     return(0L)
   }
   if (
@@ -218,7 +228,9 @@ count_motif_ <- function(
       motif_graph,
       alignment,
       strict_sub = strict_sub,
-      mode = mode
+      mode = mode,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
     )
   ) {
     return(0L)
@@ -228,7 +240,8 @@ count_motif_ <- function(
     glycan_graph,
     motif_has_linkages,
     ignore_linkages,
-    mode = mode
+    mode = mode,
+    glycan_batch_profile = glycan_batch_profile
   )
 
   # "none" is an early no-match result: the motif requires linkage information,
@@ -239,12 +252,23 @@ count_motif_ <- function(
 
   if (
     mode == "strict" &&
-      !composition_can_match(glycan_graph, motif_composition_profile)
+      !composition_can_match(
+        glycan_graph,
+        motif_composition_profile,
+        glycan_batch_profile = glycan_batch_profile,
+        motif_batch_profile = motif_batch_profile
+      )
   ) {
     return(0L)
   }
 
-  c_graphs <- colorize_graphs(glycan_graph, motif_graph, mode = mode)
+  c_graphs <- colorize_graphs(
+    glycan_graph,
+    motif_graph,
+    mode = mode,
+    glycan_batch_profile = glycan_batch_profile,
+    motif_batch_profile = motif_batch_profile
+  )
   res <- perform_vf2(
     glycan_graph,
     motif_graph,
@@ -303,15 +327,16 @@ count_motifs_ <- function(
   mode = "strict"
 ) {
   apply_motifs_to_glycans(
-    glycans,
-    motifs,
-    alignments,
-    ignore_linkages,
-    count_motif_,
-    glycan_names,
-    motif_names,
-    strict_sub,
-    match_degree,
-    mode
+    glycans = glycans,
+    motifs = motifs,
+    alignments = alignments,
+    ignore_linkages = ignore_linkages,
+    single_glycan_func = .count_motif_single,
+    glycan_names = glycan_names,
+    motif_names = motif_names,
+    strict_sub = strict_sub,
+    match_degree = match_degree,
+    mode = mode,
+    result_type = "integer"
   )
 }

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -251,13 +251,12 @@ count_motif_ <- function(
   }
 
   if (
-    mode == "strict" &&
-      !composition_can_match(
-        glycan_graph,
-        motif_composition_profile,
-        glycan_batch_profile = glycan_batch_profile,
-        motif_batch_profile = motif_batch_profile
-      )
+    !composition_can_match(
+      glycan_graph,
+      motif_composition_profile,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
+    )
   ) {
     return(0L)
   }

--- a/R/extract-motif.R
+++ b/R/extract-motif.R
@@ -188,10 +188,11 @@ extract_motif <- function(glycans, ..., max_size = 3) {
   glycans <- ensure_glycans_are_structures(glycans)
   glycans <- unique(glycans)
   structure_graphs <- glyrepr::get_structure_graphs(glycans, return_list = TRUE)
+  seen_motifs <- new.env(hash = TRUE, parent = emptyenv())
 
   extracted_subtrees <- unlist(
     purrr::map(structure_graphs, function(g) {
-      .extract_motifs_from_graph(g, max_size)
+      .extract_motifs_from_graph(g, max_size, seen_motifs)
     }),
     recursive = FALSE
   )
@@ -204,23 +205,129 @@ extract_motif <- function(glycans, ..., max_size = 3) {
   unique(res)
 }
 
-.extract_motifs_from_graph <- function(g, max_size) {
+.extract_motifs_from_graph <- function(g, max_size, seen_motifs) {
   nodes <- as.numeric(igraph::V(g))
+  key_context <- .new_motif_key_context(g)
+
   unlist(
     purrr::map(nodes, function(node) {
-      .extract_motifs_rooted_at(g, node, max_size)
+      .extract_motifs_rooted_at(
+        g,
+        node,
+        max_size,
+        seen_motifs,
+        key_context
+      )
     }),
     recursive = FALSE
   )
 }
 
-.extract_motifs_rooted_at <- function(g, root_id, max_size) {
+.extract_motifs_rooted_at <- function(
+  g,
+  root_id,
+  max_size,
+  seen_motifs,
+  key_context
+) {
   subsets <- .find_connected_subsets(g, root_id, max_size)
-  purrr::map(subsets, function(subset_nodes) {
+  anomer <- .get_node_anomer(g, root_id)
+
+  subtrees <- purrr::map(subsets, function(subset_nodes) {
+    key <- .motif_candidate_key(
+      key_context,
+      root_id,
+      subset_nodes,
+      anomer
+    )
+    if (exists(key, envir = seen_motifs, inherits = FALSE)) {
+      return(NULL)
+    }
+    assign(key, TRUE, envir = seen_motifs)
+
     subtree <- igraph::induced_subgraph(g, subset_nodes)
-    subtree$anomer <- .get_node_anomer(g, root_id)
+    subtree$anomer <- anomer
     subtree
   })
+
+  purrr::compact(subtrees)
+}
+
+.new_motif_key_context <- function(g) {
+  node_count <- igraph::vcount(g)
+  children <- rep(list(integer()), node_count)
+  child_linkages <- rep(list(character()), node_count)
+  edges <- igraph::as_edgelist(g, names = FALSE)
+
+  if (nrow(edges) > 0) {
+    linkages <- igraph::edge_attr(g, "linkage")
+    for (edge_id in seq_len(nrow(edges))) {
+      parent <- edges[edge_id, 1]
+      children[[parent]] <- c(children[[parent]], edges[edge_id, 2])
+      child_linkages[[parent]] <- c(
+        child_linkages[[parent]],
+        linkages[[edge_id]]
+      )
+    }
+  }
+
+  list(
+    mono = igraph::vertex_attr(g, "mono"),
+    sub = igraph::vertex_attr(g, "sub"),
+    children = children,
+    child_linkages = child_linkages
+  )
+}
+
+.motif_candidate_key <- function(context, root_id, subset_nodes, anomer) {
+  selected <- rep(FALSE, length(context$children))
+  selected[subset_nodes] <- TRUE
+
+  encode_node <- NULL
+  encode_node <- function(node_id) {
+    children <- context$children[[node_id]]
+    child_tokens <- character()
+
+    if (length(children) > 0) {
+      included <- selected[children]
+      children <- children[included]
+      linkages <- context$child_linkages[[node_id]][included]
+      child_tokens <- vapply(
+        seq_along(children),
+        function(i) {
+          paste0(
+            "E",
+            .motif_key_field(linkages[[i]]),
+            .motif_key_field(encode_node(children[[i]]))
+          )
+        },
+        character(1)
+      )
+      child_tokens <- sort(child_tokens)
+    }
+
+    paste0(
+      "N",
+      .motif_key_field(context$mono[[node_id]]),
+      .motif_key_field(context$sub[[node_id]]),
+      .motif_key_field(paste0(child_tokens, collapse = ""))
+    )
+  }
+
+  paste0(
+    "R",
+    .motif_key_field(anomer),
+    .motif_key_field(encode_node(root_id))
+  )
+}
+
+.motif_key_field <- function(value) {
+  if (length(value) == 0 || is.na(value)) {
+    return("M")
+  }
+
+  value <- enc2utf8(as.character(value))
+  paste0(nchar(value, type = "bytes"), ":", value)
 }
 
 .get_node_anomer <- function(g, node_id) {

--- a/R/g-motif.R
+++ b/R/g-motif.R
@@ -143,7 +143,10 @@ apply_single_motif_to_graph <- function(
 ) {
   mode <- rlang::arg_match(mode, c("strict", "lenient"))
   motif_has_linkages <- graph_has_linkages(motif_graph)
-  motif_composition_profile <- new_motif_composition_profile(motif_graph)
+  motif_composition_profile <- new_motif_composition_profile(
+    motif_graph,
+    mode = mode
+  )
   match_degree <- normalize_graph_match_degree(match_degree, motif_graph)
 
   single_glycan_func(

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -466,13 +466,12 @@ have_motif_ <- function(
   }
 
   if (
-    mode == "strict" &&
-      !composition_can_match(
-        glycan_graph,
-        motif_composition_profile,
-        glycan_batch_profile = glycan_batch_profile,
-        motif_batch_profile = motif_batch_profile
-      )
+    !composition_can_match(
+      glycan_graph,
+      motif_composition_profile,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
+    )
   ) {
     return(FALSE)
   }

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -420,11 +420,21 @@ have_motif_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
 ) {
   # Optimized version with early termination
   # Check if any match is valid, returning immediately on first valid match
-  if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
+  if (
+    !whole_alignment_size_can_match(
+      glycan_graph,
+      motif_graph,
+      alignment,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
+    )
+  ) {
     return(FALSE)
   }
   if (
@@ -433,7 +443,9 @@ have_motif_ <- function(
       motif_graph,
       alignment,
       strict_sub = strict_sub,
-      mode = mode
+      mode = mode,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
     )
   ) {
     return(FALSE)
@@ -443,7 +455,8 @@ have_motif_ <- function(
     glycan_graph,
     motif_has_linkages,
     ignore_linkages,
-    mode = mode
+    mode = mode,
+    glycan_batch_profile = glycan_batch_profile
   )
 
   # "none" is an early no-match result: the motif requires linkage information,
@@ -454,12 +467,23 @@ have_motif_ <- function(
 
   if (
     mode == "strict" &&
-      !composition_can_match(glycan_graph, motif_composition_profile)
+      !composition_can_match(
+        glycan_graph,
+        motif_composition_profile,
+        glycan_batch_profile = glycan_batch_profile,
+        motif_batch_profile = motif_batch_profile
+      )
   ) {
     return(FALSE)
   }
 
-  c_graphs <- colorize_graphs(glycan_graph, motif_graph, mode = mode)
+  c_graphs <- colorize_graphs(
+    glycan_graph,
+    motif_graph,
+    mode = mode,
+    glycan_batch_profile = glycan_batch_profile,
+    motif_batch_profile = motif_batch_profile
+  )
   res <- perform_vf2(
     glycan_graph,
     motif_graph,
@@ -526,15 +550,16 @@ have_motifs_ <- function(
   mode = "strict"
 ) {
   apply_motifs_to_glycans(
-    glycans,
-    motifs,
-    alignments,
-    ignore_linkages,
-    have_motif_,
-    glycan_names,
-    motif_names,
-    strict_sub,
-    match_degree,
-    mode
+    glycans = glycans,
+    motifs = motifs,
+    alignments = alignments,
+    ignore_linkages = ignore_linkages,
+    single_glycan_func = .have_motif_single,
+    glycan_names = glycan_names,
+    motif_names = motif_names,
+    strict_sub = strict_sub,
+    match_degree = match_degree,
+    mode = mode,
+    result_type = "logical"
   )
 }

--- a/R/match-batch.R
+++ b/R/match-batch.R
@@ -1,4 +1,4 @@
-prepare_match_batch <- function(glycans, motifs) {
+prepare_match_batch <- function(glycans, motifs, mode = "strict") {
   glycan_index <- index_unique_structures(glycans)
   motif_index <- index_unique_structures(motifs)
 
@@ -24,12 +24,22 @@ prepare_match_batch <- function(glycans, motifs) {
     unlist(motif_monos, use.names = FALSE)
   ))
 
-  motif_use_base_keys <- purrr::map_lgl(
+  motif_key_modes <- purrr::map_chr(
     motif_graphs,
-    has_fuzzy_modification
+    resolve_residue_key_mode,
+    mode = mode
   )
-  base_keys <- if (any(motif_use_base_keys)) {
+  base_keys <- if (any(motif_key_modes == "base")) {
     unique(residue_color_keys(exact_keys))
+  } else {
+    NULL
+  }
+  generic_keys <- if (any(motif_key_modes == "generic")) {
+    generic_key_vectors <- c(
+      purrr::map(glycan_monos, residue_match_keys, key_mode = "generic"),
+      purrr::map(motif_monos, residue_match_keys, key_mode = "generic")
+    )
+    unique(unlist(generic_key_vectors, use.names = FALSE))
   } else {
     NULL
   }
@@ -41,7 +51,8 @@ prepare_match_batch <- function(glycans, motifs) {
       .x,
       .y,
       exact_keys = exact_keys,
-      base_keys = base_keys
+      base_keys = base_keys,
+      generic_keys = generic_keys
     )
   )
   motif_profiles <- purrr::map2(
@@ -52,8 +63,10 @@ prepare_match_batch <- function(glycans, motifs) {
       motif_monos[[.y]],
       exact_keys = exact_keys,
       base_keys = base_keys,
-      use_base_keys = motif_use_base_keys[[.y]],
-      include_composition_profile = TRUE
+      generic_keys = generic_keys,
+      key_mode = motif_key_modes[[.y]],
+      include_composition_profile = TRUE,
+      mode = mode
     )
   )
 
@@ -95,14 +108,21 @@ new_batch_graph_profile <- function(
   monos,
   exact_keys,
   base_keys = NULL,
-  use_base_keys = FALSE,
-  include_composition_profile = FALSE
+  generic_keys = NULL,
+  key_mode = "exact",
+  include_composition_profile = FALSE,
+  mode = "strict"
 ) {
   exact_colors <- match(monos, exact_keys)
   base_colors <- if (is.null(base_keys)) {
     NULL
   } else {
     match(residue_color_keys(monos), base_keys)
+  }
+  generic_colors <- if (is.null(generic_keys)) {
+    NULL
+  } else {
+    match(residue_match_keys(monos, "generic"), generic_keys)
   }
 
   list(
@@ -113,17 +133,23 @@ new_batch_graph_profile <- function(
     ecount = igraph::ecount(graph),
     core = core_node(graph),
     has_linkages = graph_has_linkages(graph),
-    use_base_keys = use_base_keys,
+    key_mode = key_mode,
     exact_colors = exact_colors,
     base_colors = base_colors,
+    generic_colors = generic_colors,
     exact_counts = tabulate(exact_colors, nbins = length(exact_keys)),
     base_counts = if (is.null(base_colors)) {
       NULL
     } else {
       tabulate(base_colors, nbins = length(base_keys))
     },
+    generic_counts = if (is.null(generic_colors)) {
+      NULL
+    } else {
+      tabulate(generic_colors, nbins = length(generic_keys))
+    },
     composition_profile = if (include_composition_profile) {
-      new_motif_composition_profile(graph)
+      new_motif_composition_profile(graph, mode = mode)
     } else {
       NULL
     }

--- a/R/match-batch.R
+++ b/R/match-batch.R
@@ -1,0 +1,187 @@
+prepare_match_batch <- function(glycans, motifs) {
+  glycan_index <- index_unique_structures(glycans)
+  motif_index <- index_unique_structures(motifs)
+
+  glycan_graphs <- glycan_index$graphs
+  motif_graphs <- motif_index$graphs
+
+  if (identical(glyrepr::get_mono_type(motifs), "generic")) {
+    glycan_graphs <- purrr::map(glycan_graphs, convert_graph_to_generic)
+  }
+
+  glycan_monos <- purrr::map(
+    glycan_graphs,
+    igraph::vertex_attr,
+    name = "mono"
+  )
+  motif_monos <- purrr::map(
+    motif_graphs,
+    igraph::vertex_attr,
+    name = "mono"
+  )
+  exact_keys <- unique(c(
+    unlist(glycan_monos, use.names = FALSE),
+    unlist(motif_monos, use.names = FALSE)
+  ))
+
+  motif_use_base_keys <- purrr::map_lgl(
+    motif_graphs,
+    has_fuzzy_modification
+  )
+  base_keys <- if (any(motif_use_base_keys)) {
+    unique(residue_color_keys(exact_keys))
+  } else {
+    NULL
+  }
+
+  glycan_profiles <- purrr::map2(
+    glycan_graphs,
+    glycan_monos,
+    ~ new_batch_graph_profile(
+      .x,
+      .y,
+      exact_keys = exact_keys,
+      base_keys = base_keys
+    )
+  )
+  motif_profiles <- purrr::map2(
+    motif_graphs,
+    seq_along(motif_graphs),
+    ~ new_batch_graph_profile(
+      .x,
+      motif_monos[[.y]],
+      exact_keys = exact_keys,
+      base_keys = base_keys,
+      use_base_keys = motif_use_base_keys[[.y]],
+      include_composition_profile = TRUE
+    )
+  )
+
+  list(
+    glycan_profiles = glycan_profiles,
+    motif_profiles = motif_profiles,
+    glycan_restore = glycan_index$restore,
+    motif_restore = motif_index$restore
+  )
+}
+
+index_unique_structures <- function(structures) {
+  codes <- unname(as.character(structures))
+  unique_codes <- unique(codes[!is.na(codes)])
+  first <- match(unique_codes, codes)
+  graphs <- if (length(first) == 0L) {
+    list()
+  } else {
+    glyrepr::get_structure_graphs(structures[first], return_list = TRUE)
+  }
+
+  list(
+    graphs = graphs,
+    restore = match(codes, unique_codes)
+  )
+}
+
+convert_graph_to_generic <- function(graph) {
+  monos <- igraph::vertex_attr(graph, "mono")
+  igraph::set_vertex_attr(
+    graph,
+    "mono",
+    value = glyrepr::convert_to_generic(monos)
+  )
+}
+
+new_batch_graph_profile <- function(
+  graph,
+  monos,
+  exact_keys,
+  base_keys = NULL,
+  use_base_keys = FALSE,
+  include_composition_profile = FALSE
+) {
+  exact_colors <- match(monos, exact_keys)
+  base_colors <- if (is.null(base_keys)) {
+    NULL
+  } else {
+    match(residue_color_keys(monos), base_keys)
+  }
+
+  list(
+    graph = graph,
+    monos = monos,
+    subs = igraph::vertex_attr(graph, "sub"),
+    vcount = igraph::vcount(graph),
+    ecount = igraph::ecount(graph),
+    core = core_node(graph),
+    has_linkages = graph_has_linkages(graph),
+    use_base_keys = use_base_keys,
+    exact_colors = exact_colors,
+    base_colors = base_colors,
+    exact_counts = tabulate(exact_colors, nbins = length(exact_keys)),
+    base_counts = if (is.null(base_colors)) {
+      NULL
+    } else {
+      tabulate(base_colors, nbins = length(base_keys))
+    },
+    composition_profile = if (include_composition_profile) {
+      new_motif_composition_profile(graph)
+    } else {
+      NULL
+    }
+  )
+}
+
+apply_batch_motif <- function(
+  batch,
+  motif_position,
+  alignment,
+  ignore_linkages,
+  strict_sub,
+  match_degree,
+  mode,
+  single_glycan_func,
+  result_type
+) {
+  motif_profile <- batch$motif_profiles[[
+    batch$motif_restore[[motif_position]]
+  ]]
+
+  apply_one <- function(glycan_profile) {
+    single_glycan_func(
+      glycan_graph = glycan_profile$graph,
+      motif_graph = motif_profile$graph,
+      motif_has_linkages = motif_profile$has_linkages,
+      motif_composition_profile = motif_profile$composition_profile,
+      alignment = alignment,
+      ignore_linkages = ignore_linkages,
+      strict_sub = strict_sub,
+      match_degree = match_degree,
+      mode = mode,
+      glycan_batch_profile = glycan_profile,
+      motif_batch_profile = motif_profile
+    )
+  }
+
+  unique_results <- switch(
+    result_type,
+    logical = vapply(batch$glycan_profiles, apply_one, logical(1L)),
+    integer = vapply(batch$glycan_profiles, apply_one, integer(1L)),
+    list = lapply(batch$glycan_profiles, apply_one)
+  )
+
+  restore_batch_results(
+    unique_results,
+    batch$glycan_restore,
+    result_type
+  )
+}
+
+restore_batch_results <- function(results, restore, result_type) {
+  if (result_type != "list") {
+    return(results[restore])
+  }
+
+  restored <- vector("list", length(restore))
+  valid <- !is.na(restore)
+  restored[valid] <- results[restore[valid]]
+  restored
+}

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -257,37 +257,19 @@ match_motifs_ <- function(
     match_degree
   }
 
-  results <- purrr::map2(
-    motifs,
-    seq_along(motifs),
-    ~ match_motif_(
-      glycans,
-      .x,
-      alignment = alignments[[.y]],
-      ignore_linkages = ignore_linkages,
-      strict_sub = strict_sub,
-      match_degree = match_degree_list[[.y]],
-      mode = mode
-    )
+  apply_motifs_to_glycans(
+    glycans = glycans,
+    motifs = motifs,
+    alignments = alignments,
+    ignore_linkages = ignore_linkages,
+    single_glycan_func = .match_motif_single,
+    glycan_names = glycan_names,
+    motif_names = motif_names,
+    strict_sub = strict_sub,
+    match_degree = match_degree_list,
+    mode = mode,
+    result_type = "list"
   )
-
-  # Name the outer list (motifs) if motif_names provided
-  if (!is.null(motif_names)) {
-    names(results) <- motif_names
-  }
-
-  # Name the inner lists (glycans) if glycan_names provided
-  if (!is.null(glycan_names)) {
-    results <- purrr::map(
-      results,
-      ~ {
-        names(.x) <- glycan_names
-        .x
-      }
-    )
-  }
-
-  results
 }
 
 .match_motif_single <- function(
@@ -299,9 +281,19 @@ match_motifs_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  glycan_batch_profile = NULL,
+  motif_batch_profile = NULL
 ) {
-  if (!whole_alignment_size_can_match(glycan_graph, motif_graph, alignment)) {
+  if (
+    !whole_alignment_size_can_match(
+      glycan_graph,
+      motif_graph,
+      alignment,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
+    )
+  ) {
     return(list())
   }
   if (
@@ -310,7 +302,9 @@ match_motifs_ <- function(
       motif_graph,
       alignment,
       strict_sub = strict_sub,
-      mode = mode
+      mode = mode,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
     )
   ) {
     return(list())
@@ -320,7 +314,8 @@ match_motifs_ <- function(
     glycan_graph,
     motif_has_linkages,
     ignore_linkages,
-    mode = mode
+    mode = mode,
+    glycan_batch_profile = glycan_batch_profile
   )
 
   # "none" is an early no-match result: the motif requires linkage information,
@@ -331,12 +326,23 @@ match_motifs_ <- function(
 
   if (
     mode == "strict" &&
-      !composition_can_match(glycan_graph, motif_composition_profile)
+      !composition_can_match(
+        glycan_graph,
+        motif_composition_profile,
+        glycan_batch_profile = glycan_batch_profile,
+        motif_batch_profile = motif_batch_profile
+      )
   ) {
     return(list())
   }
 
-  c_graphs <- colorize_graphs(glycan_graph, motif_graph, mode = mode)
+  c_graphs <- colorize_graphs(
+    glycan_graph,
+    motif_graph,
+    mode = mode,
+    glycan_batch_profile = glycan_batch_profile,
+    motif_batch_profile = motif_batch_profile
+  )
   res <- perform_vf2(
     glycan_graph,
     motif_graph,

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -325,13 +325,12 @@ match_motifs_ <- function(
   }
 
   if (
-    mode == "strict" &&
-      !composition_can_match(
-        glycan_graph,
-        motif_composition_profile,
-        glycan_batch_profile = glycan_batch_profile,
-        motif_batch_profile = motif_batch_profile
-      )
+    !composition_can_match(
+      glycan_graph,
+      motif_composition_profile,
+      glycan_batch_profile = glycan_batch_profile,
+      motif_batch_profile = motif_batch_profile
+    )
   ) {
     return(list())
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -695,7 +695,10 @@ apply_single_motif_to_glycans <- function(
 
   motif_graph <- glyrepr::get_structure_graphs(motif)
   motif_has_linkages <- glyrepr::has_linkages(motif)[[1]]
-  motif_composition_profile <- new_motif_composition_profile(motif_graph)
+  motif_composition_profile <- new_motif_composition_profile(
+    motif_graph,
+    mode = mode
+  )
   smap_func(
     glycans_to_use,
     single_glycan_func,
@@ -815,7 +818,7 @@ apply_motifs_to_glycans <- function(
     match_degree
   }
 
-  batch <- prepare_match_batch(glycans, motifs)
+  batch <- prepare_match_batch(glycans, motifs, mode = mode)
   motif_results_list <- lapply(
     seq_along(motifs),
     function(i) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -793,15 +793,16 @@ apply_motifs_to_glycans <- function(
   motifs,
   alignments,
   ignore_linkages,
-  single_motif_func,
+  single_glycan_func,
   glycan_names,
   motif_names,
   strict_sub,
   match_degree,
-  mode
+  mode,
+  result_type
 ) {
   # Generic function to apply multiple motifs to multiple glycans
-  # single_motif_func should be either have_motif_ or count_motif_
+  # single_glycan_func is one of the graph-pair motif matching functions.
 
   # Handle empty motifs case
   if (length(motifs) == 0) {
@@ -814,19 +815,22 @@ apply_motifs_to_glycans <- function(
     match_degree
   }
 
-  # Apply each motif to all glycans using purrr
-  motif_results_list <- purrr::map2(
-    motifs,
+  batch <- prepare_match_batch(glycans, motifs)
+  motif_results_list <- lapply(
     seq_along(motifs),
-    ~ single_motif_func(
-      glycans,
-      .x,
-      alignment = alignments[[.y]],
-      ignore_linkages = ignore_linkages,
-      strict_sub = strict_sub,
-      match_degree = match_degree_list[[.y]],
-      mode = mode
-    )
+    function(i) {
+      apply_batch_motif(
+        batch = batch,
+        motif_position = i,
+        alignment = alignments[[i]],
+        ignore_linkages = ignore_linkages,
+        strict_sub = strict_sub,
+        match_degree = match_degree_list[[i]],
+        mode = mode,
+        single_glycan_func = single_glycan_func,
+        result_type = result_type
+      )
+    }
   )
 
   # Set names for the results if provided
@@ -834,8 +838,19 @@ apply_motifs_to_glycans <- function(
     names(motif_results_list) <- motif_names
   }
 
-  # Convert results to matrix format
-  # Each element in motif_results_list should be a vector of results for all glycans
+  if (result_type == "list") {
+    if (!is.null(glycan_names)) {
+      motif_results_list <- purrr::map(
+        motif_results_list,
+        function(result) {
+          names(result) <- glycan_names
+          result
+        }
+      )
+    }
+    return(motif_results_list)
+  }
+
   result_matrix <- do.call(cbind, motif_results_list)
 
   # Set rownames if provided

--- a/tests/testthat/test-extract-motif.R
+++ b/tests/testthat/test-extract-motif.R
@@ -45,6 +45,31 @@ test_that("extract_motif works for multiple glycans", {
   expect_setequal(as.character(result), as.character(expected))
 })
 
+test_that("extract_motif preserves distinct residue and linkage details", {
+  glycans <- c(
+    "Gal(a1-3)GlcNAc(a1-",
+    "Gal(b1-3)GlcNAc(a1-",
+    "Gal3S(b1-3)GlcNAc(a1-",
+    "Gal6S(b1-3)GlcNAc(a1-",
+    "Gal(b1-4)GlcNAc(a1-"
+  )
+
+  result <- extract_motif(glycans, max_size = 2)
+
+  expect_length(result, 10)
+})
+
+test_that("extract_motif keeps linkages paired with their branches", {
+  glycans <- c(
+    "Gal(b1-3)[Fuc(a1-2)]GlcNAc(a1-",
+    "Gal(a1-2)[Fuc(b1-3)]GlcNAc(a1-"
+  )
+
+  result <- extract_motif(glycans, max_size = 3)
+
+  expect_length(result, 11)
+})
+
 test_that("extract_motif's max_size works", {
   glycan <- "Glc(a1-3)Glc(a1-3)Glc(a1-3)Glc(a1-"
   result <- extract_motif(glycan, max_size = 3)

--- a/tests/testthat/test-lenient-pruning.R
+++ b/tests/testthat/test-lenient-pruning.R
@@ -1,0 +1,67 @@
+test_that("lenient fuzzy motifs bypass generic residue pruning", {
+  motif <- glyparse::parse_iupac_condensed(
+    "Gal?NAc(b1-3)Neu5Ac(a2-"
+  )
+  glycan <- glyrepr::convert_to_generic(
+    glyparse::parse_iupac_condensed("GalNAc(b1-3)Neu5Ac(a2-")
+  )
+
+  expect_true(have_motif(glycan, motif, mode = "lenient"))
+  expect_identical(count_motif(glycan, motif, mode = "lenient"), 1L)
+  expect_equal(
+    match_motif(glycan, motif, mode = "lenient"),
+    list(list(c(1L, 2L)))
+  )
+
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+  expect_true(.g_have_motif(glycan_graph, motif_graph, mode = "lenient"))
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, mode = "lenient"),
+    1L
+  )
+  expect_equal(
+    .g_match_motif(glycan_graph, motif_graph, mode = "lenient"),
+    list(c(1L, 2L))
+  )
+})
+
+test_that("plural lenient matching uses graph-local generic residue keys", {
+  glycans <- glyrepr::convert_to_generic(
+    glyparse::parse_iupac_condensed(c(
+      "GalNAc(b1-3)Neu5Ac(a2-",
+      "Gal(b1-3)Neu5Ac(a2-",
+      "Glc(b1-4)GlcNAc(a1-"
+    ))
+  )
+  motifs <- glyparse::parse_iupac_condensed(c(
+    "Gal?NAc(b1-3)Neu5Ac(a2-",
+    "Gal(b1-3)Neu5Ac(a2-",
+    "Man(b1-4)GlcNAc(a1-"
+  ))
+
+  expected_have <- diag(TRUE, 3)
+  expected_count <- diag(1L, 3)
+  expect_identical(
+    unname(have_motifs(glycans, motifs, mode = "lenient")),
+    expected_have
+  )
+  expect_identical(
+    unname(count_motifs(glycans, motifs, mode = "lenient")),
+    expected_count
+  )
+  expect_equal(
+    match_motifs(glycans, motifs, mode = "lenient"),
+    list(
+      list(list(c(1L, 2L)), list(), list()),
+      list(list(), list(c(1L, 2L)), list()),
+      list(list(), list(), list(c(1L, 2L)))
+    )
+  )
+
+  batch <- prepare_match_batch(glycans, motifs, mode = "lenient")
+  expect_identical(
+    purrr::map_chr(batch$motif_profiles, "key_mode"),
+    c("none", "generic", "generic")
+  )
+})

--- a/tests/testthat/test-match-batch.R
+++ b/tests/testthat/test-match-batch.R
@@ -77,3 +77,29 @@ test_that("batch motif functions keep per-motif degree constraints", {
     matrix(c(1L, 0L), nrow = 1)
   )
 })
+
+test_that("batch profiles keep strict fuzzy modification colors", {
+  glycans <- glyparse::parse_iupac_condensed(c(
+    match = "Glc3Me6S(a1-",
+    miss = "Glc4Me3S(a1-"
+  ))
+  motifs <- glyparse::parse_iupac_condensed(c(
+    fuzzy = "Glc?Me6S(a1-",
+    exact = "Glc3Me6S(a1-"
+  ))
+
+  batch <- prepare_match_batch(glycans, motifs)
+
+  expect_identical(
+    unname(purrr::map_chr(batch$motif_profiles, "key_mode")),
+    c("base", "exact")
+  )
+  expect_identical(
+    have_motifs(glycans, motifs),
+    matrix(
+      c(TRUE, FALSE, TRUE, FALSE),
+      nrow = 2,
+      dimnames = list(names(glycans), names(motifs))
+    )
+  )
+})

--- a/tests/testthat/test-match-batch.R
+++ b/tests/testthat/test-match-batch.R
@@ -1,0 +1,79 @@
+test_that("batch motif functions restore repeated and missing glycans", {
+  glycan_13 <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(a1-")
+  glycan_14 <- glyparse::parse_iupac_condensed("Man(b1-4)GlcNAc(a1-")
+  glycans <- c(
+    glycan_13,
+    glycan_13,
+    glyrepr::glycan_structure(NA),
+    glycan_14
+  )
+  names(glycans) <- c("g1", "g1-copy", "missing", "g2")
+  motifs <- glyparse::parse_iupac_condensed(c(
+    m13 = "Hex(b1-3)HexNAc(?1-",
+    m14 = "Hex(b1-4)HexNAc(?1-"
+  ))
+
+  expected_have <- matrix(
+    c(TRUE, TRUE, NA, FALSE, FALSE, FALSE, NA, TRUE),
+    ncol = 2,
+    dimnames = list(names(glycans), names(motifs))
+  )
+  expected_count <- matrix(
+    c(1L, 1L, NA_integer_, 0L, 0L, 0L, NA_integer_, 1L),
+    ncol = 2,
+    dimnames = list(names(glycans), names(motifs))
+  )
+  expected_match <- list(
+    m13 = list(
+      g1 = list(c(1L, 2L)),
+      `g1-copy` = list(c(1L, 2L)),
+      missing = NULL,
+      g2 = list()
+    ),
+    m14 = list(
+      g1 = list(),
+      `g1-copy` = list(),
+      missing = NULL,
+      g2 = list(c(1L, 2L))
+    )
+  )
+
+  expect_identical(have_motifs(glycans, motifs), expected_have)
+  expect_identical(count_motifs(glycans, motifs), expected_count)
+  expect_identical(match_motifs(glycans, motifs), expected_match)
+})
+
+test_that("batch motif functions preserve empty glycan shapes", {
+  glycans <- glyrepr::glycan_structure()
+  motifs <- glyparse::parse_iupac_condensed(c(
+    m1 = "Gal(b1-",
+    m2 = "GlcNAc(b1-"
+  ))
+
+  expect_identical(dim(have_motifs(glycans, motifs)), c(0L, 2L))
+  expect_identical(dim(count_motifs(glycans, motifs)), c(0L, 2L))
+  expect_identical(
+    match_motifs(glycans, motifs),
+    list(m1 = list(), m2 = list())
+  )
+})
+
+test_that("batch motif functions keep per-motif degree constraints", {
+  glycans <- glyparse::parse_iupac_condensed(
+    "Gal(b1-3)[GlcNAc(b1-6)]GalNAc(a1-"
+  )
+  motifs <- glyparse::parse_iupac_condensed(c(
+    gal = "Gal(b1-3)GalNAc(a1-",
+    glcnac = "GlcNAc(b1-6)GalNAc(a1-"
+  ))
+  match_degree <- list(c(FALSE, FALSE), c(FALSE, TRUE))
+
+  expect_identical(
+    unname(have_motifs(glycans, motifs, match_degree = match_degree)),
+    matrix(c(TRUE, FALSE), nrow = 1)
+  )
+  expect_identical(
+    unname(count_motifs(glycans, motifs, match_degree = match_degree)),
+    matrix(c(1L, 0L), nrow = 1)
+  )
+})


### PR DESCRIPTION
## Summary

- reuse parsed graphs, structure indices, residue colors, and composition profiles across `have_motifs()`, `count_motifs()`, and `match_motifs()`
- deduplicate candidate substructures before validation in `extract_motif()`
- add conservative generic-residue composition and VF2 color pruning for nonfuzzy lenient motifs, while bypassing pruning for fuzzy built-in modifications

## Benchmark design

Benchmarks use public `glydb::glydb_structures()` inputs at intact, topological, and basic structure levels, plus the full GGM motif specification. Four isolated worktrees were compared: `main` (`37b8331`), stage 1 (`5ecf0d6`), stage 2 (`d50ec5e`), and final code state (`6eff240`). PR tip `cdeae3d` only adds the live `(#50)` NEWS references.

Each revision/family ran in a fresh R process with one warmup, full GC outside the timed region, and `OMP_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, and `VECLIB_MAXIMUM_THREADS=1`. Strict workloads used four balanced execution positions; the other families used forward and reverse revision orders. Each cell contains 3 or 5 repetitions per block (12/20 observations for strict workloads, 6/10 otherwise). Values are median seconds [Q1–Q3]; speedups are descriptive ratios of pooled medians, not confidence intervals.

Environment: Apple M3 MacBook Air (8 cores, 16 GB), macOS 26.5.2, R 4.6.1, glydb 0.6.0, glyrepr 0.13.0, and glyparse 0.7.1.

### Stage 1: shared batch metadata

| Workload | main, s | stage 1, s | Stage 1 speedup | HEAD speedup |
| --- | --- | --- | --- | --- |
| `have_motifs()`, strict, 50 × 20 | 0.243 [0.235–0.257] | 0.142 [0.136–0.218] | 1.71× | 1.48× |
| `have_motifs()`, strict, 100 × 40 | 0.982 [0.965–1.054] | 0.599 [0.527–0.773] | 1.64× | 1.59× |
| `count_motifs()`, strict, 100 × 40 | 1.121 [1.049–1.204] | 0.670 [0.560–0.754] | 1.67× | 1.84× |
| `match_motifs()`, strict, 50 × 20 | 0.254 [0.248–0.286] | 0.161 [0.142–0.175] | 1.58× | 1.49× |
| `have_motifs()`, strict, 100 × 178 GGM | 4.373 [4.156–4.810] | 2.157 [1.950–2.942] | 2.03× | 2.01× |
| `have_motifs()`, intact × basic, 100 × 40 | 1.274 [1.226–1.464] | 0.244 [0.233–0.262] | 5.21× | 5.85× |
| `count_motifs()`, intact × basic, 100 × 40 | 1.413 [1.337–1.543] | 0.279 [0.263–0.316] | 5.07× | 6.81× |
| `match_motifs()`, intact × basic, 50 × 20 | 0.435 [0.383–0.485] | 0.100 [0.094–0.108] | 4.37× | 4.51× |

### Stage 2: duplicate-free extraction

| Workload | stage 1, s | stage 2, s | Stage 2 speedup | HEAD speedup |
| --- | --- | --- | --- | --- |
| intact, n = 25, `max_size = 2` | 1.052 [0.867–1.270] | 0.268 [0.210–0.331] | 3.93× | 1.57× |
| intact, n = 25, `max_size = 3` | 0.938 [0.804–1.113] | 0.599 [0.515–0.744] | 1.57× | 1.56× |
| intact, n = 25, `max_size = 4` | 1.391 [1.168–1.542] | 0.571 [0.486–0.667] | 2.44× | 1.30× |
| intact, n = 100, `max_size = 3` | 10.331 [8.161–11.649] | 2.615 [2.289–3.002] | 3.95× | 3.33× |
| topological, n = 25, `max_size = 3` | 1.472 [1.259–1.968] | 0.795 [0.631–1.137] | 1.85× | 2.91× |
| basic, n = 25, `max_size = 3` | 1.978 [1.457–2.103] | 0.421 [0.334–0.547] | 4.71× | 4.38× |

### Stage 3: conservative lenient pruning

| Workload | stage 2, s | HEAD, s | Stage 3 speedup | HEAD speedup |
| --- | --- | --- | --- | --- |
| `have_motifs()`, lenient, 40 × 20 | 1.810 [1.377–2.211] | 0.485 [0.449–0.598] | 3.73× | 4.56× |
| `count_motifs()`, lenient, 40 × 20 | 2.634 [1.731–3.710] | 0.566 [0.493–0.609] | 4.65× | 4.23× |
| `match_motifs()`, lenient, 40 × 20 | 1.901 [1.687–2.202] | 0.933 [0.768–1.317] | 2.04× | 2.67× |

All 17 workloads used identical input hashes and produced identical saved outputs across every revision/block. Matching outputs were compared as exact R objects; extraction outputs were compared as ordered IUPAC character vectors.

## Verification

- `Rscript --vanilla -e 'devtools::document()'`
- `Rscript --vanilla -e 'devtools::test(stop_on_failure = TRUE)'`: 572 passed, 0 failed, with one existing `glyexp::experiment()` deprecation warning
- `Rscript --vanilla -e 'devtools::check(error_on = "warning")'`: 0 errors, 0 warnings, 1 environment NOTE (remote time could not be verified)
- `air format .`
- `git diff --check`
