### PR TITLE
fix: warn for non-N branch motif inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # glymotif (development version)
 
+* `extract_branch_motif()` now warns, rather than errors, for glycans without
+  the N-glycan core, returning no branch motifs for those inputs. (#51)
+
 * `have_motifs()`, `count_motifs()`, and `match_motifs()` now reuse graph metadata across batch matching, substantially reducing runtime for many-glycan, many-motif analyses. (#50)
 
 * `extract_motif()` now discards duplicate candidates before constructing subgraphs, substantially reducing dynamic-motif extraction time. (#50)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,8 @@
 # glymotif (development version)
 
-* `extract_branch_motif()` now warns, rather than errors, for glycans without
-  the N-glycan core, returning no branch motifs for those inputs. (#51)
-
+* `extract_branch_motif()` now warns, rather than errors, for glycans without the N-glycan core, returning no branch motifs for those inputs. (#51)
 * `have_motifs()`, `count_motifs()`, and `match_motifs()` now reuse graph metadata across batch matching, substantially reducing runtime for many-glycan, many-motif analyses. (#50)
-
 * `extract_motif()` now discards duplicate candidates before constructing subgraphs, substantially reducing dynamic-motif extraction time. (#50)
-
 * Lenient motif matching now uses conservative generic-residue filters to avoid unnecessary graph searches while preserving fuzzy-modification matching. (#50)
 
 # glymotif 0.17.2

--- a/R/extract-motif.R
+++ b/R/extract-motif.R
@@ -147,7 +147,7 @@ extract_branch_motif <- function(glycans, ..., including_core = FALSE) {
   )
   have_n_motif <- have_motif(glycans, n_motif, alignment = "core")
   if (!all(have_n_motif)) {
-    cli::cli_abort(c(
+    cli::cli_warn(c(
       "{.arg glycans} must be N-glycans.",
       "x" = "Some of {.arg glycans} do not have the N-glycan core motif."
     ))

--- a/R/extract-motif.R
+++ b/R/extract-motif.R
@@ -148,8 +148,8 @@ extract_branch_motif <- function(glycans, ..., including_core = FALSE) {
   have_n_motif <- have_motif(glycans, n_motif, alignment = "core")
   if (!all(have_n_motif)) {
     cli::cli_warn(c(
-      "{.arg glycans} must be N-glycans.",
-      "x" = "Some of {.arg glycans} do not have the N-glycan core motif."
+      "!" = "Some of {.arg glycans} do not have the N-glycan core motif.",
+      "!" = "Those glycans are skipped."
     ))
   }
 }

--- a/tests/testthat/_snaps/extract-motif.md
+++ b/tests/testthat/_snaps/extract-motif.md
@@ -1,4 +1,5 @@
 # extract_branch_motif warns for glycans other than N-glycans
 
-    `glycans` must be N-glycans.
-    x Some of `glycans` do not have the N-glycan core motif.
+    ! Some of `glycans` do not have the N-glycan core motif.
+    ! Those glycans are skipped.
+

--- a/tests/testthat/_snaps/extract-motif.md
+++ b/tests/testthat/_snaps/extract-motif.md
@@ -1,0 +1,4 @@
+# extract_branch_motif warns for glycans other than N-glycans
+
+    `glycans` must be N-glycans.
+    x Some of `glycans` do not have the N-glycan core motif.

--- a/tests/testthat/test-extract-motif.R
+++ b/tests/testthat/test-extract-motif.R
@@ -157,9 +157,10 @@ test_that("extract_branch_motif works for glycans with complex branching pattern
   expect_setequal(as.character(res), as.character(expected))
 })
 
-test_that("extract_branch_motif rejects glycans other than N-glycans", {
-  glycan <- "Gal(b1-3)GalNAc(a1-"
-  expect_error(extract_branch_motif(glycan), "must be N-glycans")
+test_that("extract_branch_motif warns for glycans other than N-glycans", {
+  paucimannose <- "Man(a1-6)Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+  expect_snapshot_warning(extract_branch_motif(paucimannose))
+  expect_length(suppressWarnings(extract_branch_motif(paucimannose)), 0)
 })
 
 test_that("optional extract_branch_motif arguments must be named", {


### PR DESCRIPTION
## Summary
- Change `extract_branch_motif()` to warn instead of erroring when glycans lack the N-glycan core.
- Return an empty branch-motif vector for paucimannose inputs and cover the warning with a regression snapshot.
- Document the behavior in `NEWS.md`. (#51)

## Verification
- `Rscript -e 'devtools::test()'`
- `Rscript -e 'devtools::check(args = "--no-manual", error_on = "warning")'`