### PR TITLE
feat: support mixed generic and concrete residues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Roxygen: list(markdown = TRUE)
 URL: https://glycoverse.github.io/glymotif/, https://github.com/glycoverse/glymotif
 Imports: 
     cli,
-    glyrepr (>= 0.14.0),
+    glyrepr (>= 0.14.0.9000),
     glyparse (>= 0.6.0),
     glydraw (>= 0.4.0),
     igraph,
@@ -40,3 +40,5 @@ Depends:
 VignetteBuilder: knitr
 BugReports: https://github.com/glycoverse/glymotif/issues
 RoxygenNote: 7.3.3
+Remotes:  
+    glycoverse/glyrepr

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics.
+* Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics. (#55)
 
 # glymotif 0.18.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glymotif (development version)
 
+## New features
+
+* Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics.
+
 # glymotif 0.18.1
 
 # glymotif 0.18.0

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -145,11 +145,22 @@ resolve_residue_key_mode <- function(motif, mode = "strict") {
     return("generic")
   }
 
-  if (fuzzy) {
-    "base"
-  } else {
-    "exact"
+  motif_type <- graph_mono_type(motif)
+  if (motif_type == "mixed") {
+    return("none")
   }
+
+  if (fuzzy) {
+    if (motif_type == "generic") {
+      return("none")
+    }
+    return("base")
+  }
+
+  if (motif_type == "generic") {
+    return("generic")
+  }
+  "exact"
 }
 
 
@@ -845,19 +856,19 @@ match_mono <- function(glycan_mono, motif_mono, mode = "strict") {
     return(TRUE)
   }
 
-  if (mode != "lenient") {
-    return(FALSE)
-  }
-
   glycan_type <- glyrepr::get_mono_type(glycan_mono)
   motif_type <- glyrepr::get_mono_type(motif_mono)
 
-  if (glycan_type == "generic" && motif_type == "concrete") {
-    return(glycan_mono == glyrepr::convert_to_generic(motif_mono))
-  }
-
   if (glycan_type == "concrete" && motif_type == "generic") {
     return(glyrepr::convert_to_generic(glycan_mono) == motif_mono)
+  }
+
+  if (
+    mode == "lenient" &&
+      glycan_type == "generic" &&
+      motif_type == "concrete"
+  ) {
+    return(glycan_mono == glyrepr::convert_to_generic(motif_mono))
   }
 
   FALSE

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -78,7 +78,7 @@
 #' print(result)
 #'
 #' # Monosaccharide type matching examples
-#' # Concrete glycan vs generic motif: matches (glycan converted to generic)
+#' # Concrete glycan vs generic motif: compatible residues match
 #' count_motif("Man(?1-", "Hex(?1-") # Returns 1
 #'
 #' # Generic glycan vs concrete motif: doesn't match

--- a/R/extract-motif.R
+++ b/R/extract-motif.R
@@ -26,7 +26,9 @@
 #'   arguments to be supplied by name.
 #' @param including_core A logical scalar. If `TRUE`, the N-glycan core structure
 #'   (`Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-` or `Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-`)
-#'   is appended to each branch motif. Default is `FALSE`.
+#'   is appended to each branch motif. Concrete branches receive a concrete
+#'   core; generic and mixed branches receive a generic core. Default is
+#'   `FALSE`.
 #'
 #' @details
 #' The function works by:
@@ -129,11 +131,11 @@ extract_branch_motif <- function(glycans, ..., including_core = FALSE) {
   # Optionally append core structure
   if (including_core && length(res) > 0) {
     mono_type <- structure_mono_type(res)
-    core_suffix <- if (mono_type == "concrete") {
-      "?)Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-"
-    } else {
+    core_suffix <- ifelse(
+      mono_type == "concrete",
+      "?)Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-",
       "?)Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-"
-    }
+    )
 
     res_chars <- as.character(res)
     # Append core suffix to each branch (position is always ?)

--- a/R/g-motif.R
+++ b/R/g-motif.R
@@ -22,11 +22,9 @@
 #'   motif fields.
 #'
 #' @details
-#' These functions do no validation, parsing, naming, or monosaccharide-type
-#' conversion. Callers must provide valid, already-compatible graph objects.
-#' In strict mode, when matching a generic motif graph, callers must pass a
-#' glycan graph whose `mono` vertex attributes have already been converted to
-#' the compatible generic representation.
+#' These functions do no validation, parsing, naming, or graph mutation.
+#' Callers must provide valid graph objects. Residue compatibility follows the
+#' high-level matching rules, including generic and mixed motif residues.
 #'
 #' These functions never call [glyrepr::as_glycan_structure()].
 #'

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -27,24 +27,29 @@
 #'
 #' # Monosaccharide type
 #'
-#' As of glyrepr 0.9.0.9000, all elements in a `glycans` or `motifs` vector
-#' must have the same monosaccharide type ("concrete" or "generic").
-#' This invariant is enforced when creating or combining `glyrepr_structure` objects.
-#' The matching rules are:
-#' - When the motif is "generic", glycans are converted to "generic" type for comparison,
-#'   allowing both concrete and generic glycans to match generic motifs.
-#' - When the motif is "concrete", glycans are used as-is, so only concrete glycans
-#'   with matching monosaccharide names will match, while generic glycans will not match.
+#' Glycans and motifs can each contain concrete residues, generic residues, or
+#' a mixture of both. Structure vectors can likewise combine concrete, generic,
+#' and mixed elements. Matching is performed residue by residue for every
+#' glycan-motif pair; structures are not converted as a whole.
+#'
+#' In the default strict mode:
+#' - Concrete glycan residues match the same concrete motif residue.
+#' - Concrete glycan residues also match compatible generic motif residues.
+#' - Generic glycan residues do not match concrete motif residues.
+#' - Generic glycan residues match the same generic motif residue.
+#' - Concrete residues with different identities never match.
 #'
 #' Examples:
-#' - `Man` (concrete glycan) vs `Hex` (generic motif) → TRUE (Man converted to Hex for comparison)
-#' - `Hex` (generic glycan) vs `Man` (concrete motif) → FALSE (names don't match)
-#' - `Man` (concrete glycan) vs `Man` (concrete motif) → TRUE (exact match)
-#' - `Hex` (generic glycan) vs `Hex` (generic motif) → TRUE (exact match)
+#' - `Man` (concrete glycan) vs `Hex` (generic motif) → TRUE
+#' - `Hex` (generic glycan) vs `Man` (concrete motif) → FALSE
+#' - `Man` (concrete glycan) vs `Man` (concrete motif) → TRUE
+#' - `Hex` (generic glycan) vs `Hex` (generic motif) → TRUE
+#' - `Gal(b1-3)GalNAc` (concrete glycan) vs `Hex(b1-3)GalNAc`
+#'   (mixed motif) → TRUE
 #'
-#' With `mode = "lenient"`, generic glycan residues can match compatible
-#' concrete motif residues. For example, `Hex` can match a `Gal` motif residue,
-#' but `HexNAc` still cannot match `Gal`.
+#' With `mode = "lenient"`, compatibility becomes bidirectional: generic glycan
+#' residues can also match compatible concrete motif residues. For example,
+#' `Hex` can match a `Gal` motif residue, but `HexNAc` still cannot match `Gal`.
 #'
 #' # Linkages
 #'

--- a/R/igraph-utils.R
+++ b/R/igraph-utils.R
@@ -115,46 +115,50 @@ graph_mono_type <- function(graph) {
 }
 
 structure_mono_type <- function(structures) {
-  if (length(structures) == 0L) {
-    return(character())
+  restore_structure_graph_values(structures, graph_mono_type)
+}
+
+restore_structure_graph_values <- function(structures, summarize_graph) {
+  index <- index_unique_structures(structures)
+  values <- vapply(index$graphs, summarize_graph, character(1L))
+  result <- values[index$restore]
+  names(result) <- names(structures)
+  result
+}
+
+graph_linkages <- function(graph) {
+  linkages <- graph_edge_attr(graph, "linkage")
+  floating_parts <- igraph::graph_attr(graph, "floating_parts")
+  if (length(floating_parts) > 0L) {
+    linkages <- c(
+      linkages,
+      vapply(floating_parts, \(part) part$linkage, character(1L))
+    )
   }
-  graphs <- attr(structures, "graphs")
-  if (length(graphs) == 0L) {
-    return(NA_character_)
-  }
-  graph_mono_type(graphs[[1]])
+  linkages
 }
 
 graph_has_linkages <- function(graph) {
-  any(graph_edge_attr(graph, "linkage") != "??-?") ||
+  any(graph_linkages(graph) != "??-?") ||
     igraph::graph_attr(graph, "anomer") != "??"
 }
 
 graph_has_strict_linkages <- function(graph) {
-  linkages <- graph_edge_attr(graph, "linkage")
+  linkages <- graph_linkages(graph)
   anomer <- igraph::graph_attr(graph, "anomer")
   all(!stringr::str_detect(c(linkages, anomer), stringr::fixed("?"))) &&
     all(!stringr::str_detect(linkages, stringr::fixed("/")))
 }
 
 structure_level <- function(structures) {
-  codes <- as.character(structures)
-  valid_codes <- unique(codes[!is.na(codes)])
-  if (length(valid_codes) == 0L) {
-    return(NA_character_)
-  }
+  restore_structure_graph_values(structures, graph_structure_level)
+}
 
-  graphs <- attr(structures, "graphs")[valid_codes]
-  if (graph_mono_type(graphs[[1]]) == "generic") {
-    return("basic")
-  }
-
-  strict <- vapply(graphs, graph_has_strict_linkages, logical(1L))
-  if (all(strict)) {
+graph_structure_level <- function(graph) {
+  if (graph_has_strict_linkages(graph)) {
     return("intact")
   }
-  lenient <- vapply(graphs, graph_has_linkages, logical(1L))
-  if (any(lenient)) {
+  if (graph_has_linkages(graph)) {
     return("partial")
   }
   "topological"

--- a/R/match-batch.R
+++ b/R/match-batch.R
@@ -5,10 +5,6 @@ prepare_match_batch <- function(glycans, motifs, mode = "strict") {
   glycan_graphs <- glycan_index$graphs
   motif_graphs <- motif_index$graphs
 
-  if (identical(structure_mono_type(motifs), "generic")) {
-    glycan_graphs <- purrr::map(glycan_graphs, convert_graph_to_generic)
-  }
-
   glycan_monos <- purrr::map(
     glycan_graphs,
     graph_vertex_attr,
@@ -91,17 +87,6 @@ index_unique_structures <- function(structures) {
   list(
     graphs = graphs,
     restore = match(codes, unique_codes)
-  )
-}
-
-convert_graph_to_generic <- function(graph) {
-  vertex_ids <- graph_vertex_ids(graph)
-  monos <- graph_vertex_attr(graph, "mono", vertex_ids)
-  igraph::set_vertex_attr(
-    graph,
-    "mono",
-    index = vertex_ids,
-    value = glyrepr::convert_to_generic(monos)
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -81,7 +81,7 @@ prepare_motif_args <- function(
     call = call
   )
   if (mode == "strict") {
-    warn_mismatched_structure_levels(glycans, motifs)
+    warn_uniformly_incompatible_inputs(glycans, motifs)
   }
 
   new_prepared_motif_args(
@@ -96,40 +96,72 @@ prepare_motif_args <- function(
   )
 }
 
-#' Warn About Mismatched Structure Levels
+#' Warn About Uniformly Incompatible Matching Inputs
 #'
-#' Informs users when lower-information `glycans` are matched against
-#' higher-information `motifs`, a common mistake that usually returns no matches.
+#' Informs users when the mono types or structure levels guarantee that every
+#' requested strict match will fail.
 #'
 #' @param glycans A normalized glycan structure vector.
 #' @param motifs A normalized motif structure vector.
 #'
 #' @return `NULL`, invisibly.
 #' @noRd
-warn_mismatched_structure_levels <- function(glycans, motifs) {
-  glycan_level <- structure_level(glycans)
-  motif_level <- structure_level(motifs)
+warn_uniformly_incompatible_inputs <- function(glycans, motifs) {
+  glycan_types <- structure_mono_type(glycans)
+  motif_types <- structure_mono_type(motifs)
+  glycan_types <- glycan_types[!is.na(glycan_types)]
+  motif_types <- motif_types[!is.na(motif_types)]
 
-  if (
-    isTRUE(
-      glycan_level == "topological" &&
-        motif_level %in% c("intact", "partial")
-    )
-  ) {
-    warn_structure_level_mismatch(glycan_level, motif_level)
+  all_glycans_generic <- length(glycan_types) > 0L &&
+    all(glycan_types == "generic")
+  all_motifs_concrete <- length(motif_types) > 0L &&
+    all(motif_types == "concrete")
+  if (all_glycans_generic && all_motifs_concrete) {
+    warn_mono_type_mismatch()
+    return(invisible(NULL))
   }
 
-  if (isTRUE(glycan_level == "basic" && motif_level != "basic")) {
-    warn_structure_level_mismatch(glycan_level, motif_level)
+  glycan_levels <- structure_level(glycans)
+  motif_levels <- structure_level(motifs)
+  glycan_levels <- glycan_levels[!is.na(glycan_levels)]
+  motif_levels <- motif_levels[!is.na(motif_levels)]
+  all_glycans_topological <- length(glycan_levels) > 0L &&
+    all(glycan_levels == "topological")
+  all_motifs_higher <- length(motif_levels) > 0L &&
+    all(motif_levels %in% c("intact", "partial"))
+
+  if (all_glycans_topological && all_motifs_higher) {
+    warn_structure_level_mismatch(
+      "topological",
+      paste(unique(motif_levels), collapse = "/")
+    )
   }
 
   invisible(NULL)
 }
 
+#' Emit Monosaccharide-Type Mismatch Warning
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+warn_mono_type_mismatch <- function() {
+  cli::cli_warn(
+    c(
+      "Matching generic {.arg glycans} against concrete {.arg motifs} always returns no matches in strict mode.",
+      "i" = "Convert motifs with `glyrepr::convert_to_generic()`, or use {.code mode = \"lenient\"} when generic identities should match their concrete counterparts."
+    ),
+    class = c(
+      "warning_mismatched_mono_type",
+      "warning_mismatched_structure_level"
+    )
+  )
+  invisible(NULL)
+}
+
 #' Emit Structure-Level Mismatch Warning
 #'
-#' @param glycan_level The aggregate structure level of `glycans`.
-#' @param motif_level The aggregate structure level of `motifs`.
+#' @param glycan_level The mismatched structure level in `glycans`.
+#' @param motif_level The higher structure level or levels in `motifs`.
 #'
 #' @return `NULL`, invisibly.
 #' @noRd
@@ -138,7 +170,7 @@ warn_structure_level_mismatch <- function(glycan_level, motif_level) {
     c(
       "Matching lower-level {.arg glycans} against higher-level {.arg motifs} usually returns no matches.",
       "i" = "{.arg glycans} have {.val {glycan_level}} structure level, while {.arg motifs} have {.val {motif_level}} structure level.",
-      "i" = "Use motifs at the same structure level as the glycans, or reduce motif structure levels before matching.",
+      "i" = "Use motifs at the same structure level as the glycans, or remove motif linkage constraints with `glyrepr::remove_linkages()`.",
       "i" = "See {.code ?get_structure_level} for details."
     ),
     class = "warning_mismatched_structure_level"
@@ -680,19 +712,6 @@ apply_single_motif_to_glycans <- function(
   # single_glycan_func should be either .have_motif_single or .count_motif_single
   # smap_func should be either glyrepr::smap_lgl or glyrepr::smap_int
 
-  # Handle mono type conversion based on motif type
-  # glyrepr 0.9.0.9000 guarantees all elements in a glyrepr_structure vector
-  # have the same mono_type, so get_mono_type() returns a scalar
-  motif_type <- structure_mono_type(motif)
-  if (motif_type == "generic") {
-    # For generic motifs, convert glycans to generic to allow matching concrete glycans
-    glycans_to_use <- fast_convert_to_generic(glycans)
-  } else {
-    # For concrete motifs, use glycans as-is
-    # (generic glycans will naturally not match due to different mono names)
-    glycans_to_use <- glycans
-  }
-
   motif_graph <- glyrepr::get_structure_graphs(motif)
   motif_has_linkages <- graph_has_linkages(motif_graph)
   motif_composition_profile <- new_motif_composition_profile(
@@ -700,7 +719,7 @@ apply_single_motif_to_glycans <- function(
     mode = mode
   )
   smap_func(
-    glycans_to_use,
+    glycans,
     single_glycan_func,
     motif_graph,
     motif_has_linkages,
@@ -711,30 +730,6 @@ apply_single_motif_to_glycans <- function(
     match_degree,
     mode
   )
-}
-
-#' Fast Convert Mono Types
-#'
-#' `apply_single_motif_to_glycans` used to use
-#' `glyrepr::convert_to_generic()` to ensure that mono types of glycans and
-#' motifs are the same. That function rebuilds the structure representation
-#' after applying the graph transformation.
-#' However, in motif mathcing functions of `glymotif`,
-#' we don't need to return the converted `glyrepr::glycan_structure()` object.
-#' All we need to do is to make sure the underlying glycan graphs are of correct mono types.
-#' Therefore, we implement a fast version of `convert_to_generic()` here
-#' for this special use case.
-#' It only converts the underlying graphs without modifying anything else.
-#' The transformed graphs are trusted internal values and can therefore use
-#' the low-level `glyrepr::new_glycan_structure()` constructor.
-#'
-#' @param glycans A `glyrepr_structure` object.
-#' @return A `glyrepr_structure` object with the same IUPACs but generic mono types.
-#' @noRd
-fast_convert_to_generic <- function(glycans) {
-  iupacs <- as.character(glycans)
-  new_graphs <- purrr::map(attr(glycans, "graphs"), convert_graph_to_generic)
-  glyrepr::new_glycan_structure(iupacs, new_graphs)
 }
 
 # ----- Generic function for multiple motifs -----

--- a/man/count_motif.Rd
+++ b/man/count_motif.Rd
@@ -182,7 +182,7 @@ result <- count_motifs(glycans, motifs)
 print(result)
 
 # Monosaccharide type matching examples
-# Concrete glycan vs generic motif: matches (glycan converted to generic)
+# Concrete glycan vs generic motif: compatible residues match
 count_motif("Man(?1-", "Hex(?1-") # Returns 1
 
 # Generic glycan vs concrete motif: doesn't match

--- a/man/dot-g_motif.Rd
+++ b/man/dot-g_motif.Rd
@@ -77,11 +77,9 @@ and \code{\link[=match_motif]{match_motif()}} for package code that already has 
 objects from \code{\link[glyrepr:get_structure_graphs]{glyrepr::get_structure_graphs()}}.
 }
 \details{
-These functions do no validation, parsing, naming, or monosaccharide-type
-conversion. Callers must provide valid, already-compatible graph objects.
-In strict mode, when matching a generic motif graph, callers must pass a
-glycan graph whose \code{mono} vertex attributes have already been converted to
-the compatible generic representation.
+These functions do no validation, parsing, naming, or graph mutation.
+Callers must provide valid graph objects. Residue compatibility follows the
+high-level matching rules, including generic and mixed motif residues.
 
 These functions never call \code{\link[glyrepr:as_glycan_structure]{glyrepr::as_glycan_structure()}}.
 }

--- a/man/extract_branch_motif.Rd
+++ b/man/extract_branch_motif.Rd
@@ -18,7 +18,9 @@ arguments to be supplied by name.}
 
 \item{including_core}{A logical scalar. If \code{TRUE}, the N-glycan core structure
 (\verb{Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-} or \verb{Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-})
-is appended to each branch motif. Default is \code{FALSE}.}
+is appended to each branch motif. Concrete branches receive a concrete
+core; generic and mixed branches receive a generic core. Default is
+\code{FALSE}.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector containing the unique extracted branching motifs.

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -119,28 +119,33 @@ Motif names have the following rules:
 }
 
 \section{Monosaccharide type}{
-As of glyrepr 0.9.0.9000, all elements in a \code{glycans} or \code{motifs} vector
-must have the same monosaccharide type ("concrete" or "generic").
-This invariant is enforced when creating or combining \code{glyrepr_structure} objects.
-The matching rules are:
+Glycans and motifs can each contain concrete residues, generic residues, or
+a mixture of both. Structure vectors can likewise combine concrete, generic,
+and mixed elements. Matching is performed residue by residue for every
+glycan-motif pair; structures are not converted as a whole.
+
+In the default strict mode:
 \itemize{
-\item When the motif is "generic", glycans are converted to "generic" type for comparison,
-allowing both concrete and generic glycans to match generic motifs.
-\item When the motif is "concrete", glycans are used as-is, so only concrete glycans
-with matching monosaccharide names will match, while generic glycans will not match.
+\item Concrete glycan residues match the same concrete motif residue.
+\item Concrete glycan residues also match compatible generic motif residues.
+\item Generic glycan residues do not match concrete motif residues.
+\item Generic glycan residues match the same generic motif residue.
+\item Concrete residues with different identities never match.
 }
 
 Examples:
 \itemize{
-\item \code{Man} (concrete glycan) vs \code{Hex} (generic motif) → TRUE (Man converted to Hex for comparison)
-\item \code{Hex} (generic glycan) vs \code{Man} (concrete motif) → FALSE (names don't match)
-\item \code{Man} (concrete glycan) vs \code{Man} (concrete motif) → TRUE (exact match)
-\item \code{Hex} (generic glycan) vs \code{Hex} (generic motif) → TRUE (exact match)
+\item \code{Man} (concrete glycan) vs \code{Hex} (generic motif) → TRUE
+\item \code{Hex} (generic glycan) vs \code{Man} (concrete motif) → FALSE
+\item \code{Man} (concrete glycan) vs \code{Man} (concrete motif) → TRUE
+\item \code{Hex} (generic glycan) vs \code{Hex} (generic motif) → TRUE
+\item \verb{Gal(b1-3)GalNAc} (concrete glycan) vs \verb{Hex(b1-3)GalNAc}
+(mixed motif) → TRUE
 }
 
-With \code{mode = "lenient"}, generic glycan residues can match compatible
-concrete motif residues. For example, \code{Hex} can match a \code{Gal} motif residue,
-but \code{HexNAc} still cannot match \code{Gal}.
+With \code{mode = "lenient"}, compatibility becomes bidirectional: generic glycan
+residues can also match compatible concrete motif residues. For example,
+\code{Hex} can match a \code{Gal} motif residue, but \code{HexNAc} still cannot match \code{Gal}.
 }
 
 \section{Linkages}{

--- a/tests/testthat/_snaps/have-motif.md
+++ b/tests/testthat/_snaps/have-motif.md
@@ -1,0 +1,39 @@
+# all-generic glycans and all-concrete motifs warn
+
+    Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
+    i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
+
+---
+
+    Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
+    i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
+
+---
+
+    Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
+    i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
+
+# all-topological glycans and higher-level motifs warn
+
+    Matching lower-level `glycans` against higher-level `motifs` usually returns no matches.
+    i `glycans` have "topological" structure level, while `motifs` have "intact" structure level.
+    i Use motifs at the same structure level as the glycans, or remove motif linkage constraints with `glyrepr::remove_linkages()`.
+    i See `?get_structure_level` for details.
+
+---
+
+    Matching lower-level `glycans` against higher-level `motifs` usually returns no matches.
+    i `glycans` have "topological" structure level, while `motifs` have "intact/partial" structure level.
+    i Use motifs at the same structure level as the glycans, or remove motif linkage constraints with `glyrepr::remove_linkages()`.
+    i See `?get_structure_level` for details.
+
+# have_motif: generic glycan does not match concrete motif
+
+    Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
+    i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
+
+# have_motif: complex structures with type conversion
+
+    Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
+    i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
+

--- a/tests/testthat/test-extract-motif.R
+++ b/tests/testthat/test-extract-motif.R
@@ -202,3 +202,29 @@ test_that("extract_branch_motif with including_core works for glycans without li
   ))
   expect_setequal(as.character(res), as.character(expected))
 })
+
+test_that("extract_branch_motif appends cores element-wise for mixed vectors", {
+  concrete <- glyrepr::as_glycan_structure(
+    "Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(a1-4)GlcNAc(b1-"
+  )
+  generic <- glyrepr::convert_to_generic(concrete)
+  mixed <- glyrepr::as_glycan_structure(
+    "Hex(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(a1-4)GlcNAc(b1-"
+  )
+
+  result <- extract_branch_motif(
+    c(concrete = concrete, generic = generic, mixed = mixed),
+    including_core = TRUE
+  )
+  expected <- glyrepr::as_glycan_structure(c(
+    "Gal(b1-4)GlcNAc(b1-?)Man(??-?)Man(??-?)GlcNAc(??-?)GlcNAc(??-",
+    "Hex(b1-4)HexNAc(b1-?)Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-",
+    "Hex(b1-4)GlcNAc(b1-?)Hex(??-?)Hex(??-?)HexNAc(??-?)HexNAc(??-"
+  ))
+
+  expect_identical(as.character(result), as.character(expected))
+  expect_identical(
+    glyrepr::get_mono_type(result),
+    c("concrete", "generic", "mixed")
+  )
+})

--- a/tests/testthat/test-g-motif.R
+++ b/tests/testthat/test-g-motif.R
@@ -70,20 +70,25 @@ test_that("optional .g_* motif arguments must be named", {
   )
 })
 
-test_that(".g_* motif functions keep mono-type compatibility as caller contract", {
-  glycan <- glyrepr::as_glycan_structure("Man(?1-")
-  generic_motif <- glyrepr::as_glycan_structure("Hex(?1-")
-  glycan_graph <- glyrepr::get_structure_graphs(glycan)
-  generic_motif_graph <- glyrepr::get_structure_graphs(generic_motif)
+test_that(".g_* motif functions support generic and mixed residue rules", {
+  concrete <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  generic <- glyrepr::as_glycan_structure("Hex(b1-3)HexNAc(a1-")
+  mixed_motif <- glyrepr::as_glycan_structure("Hex(b1-3)GalNAc(a1-")
+  concrete_graph <- glyrepr::get_structure_graphs(concrete)
+  generic_graph <- glyrepr::get_structure_graphs(generic)
+  mixed_motif_graph <- glyrepr::get_structure_graphs(mixed_motif)
 
-  expect_false(.g_have_motif(glycan_graph, generic_motif_graph))
-  expect_identical(.g_count_motif(glycan_graph, generic_motif_graph), 0L)
-  expect_equal(.g_match_motif(glycan_graph, generic_motif_graph), list())
-
-  igraph::V(glycan_graph)$mono <- glyrepr::convert_to_generic(
-    igraph::V(glycan_graph)$mono
+  expect_identical(.g_have_motif(concrete_graph, mixed_motif_graph), TRUE)
+  expect_identical(.g_count_motif(concrete_graph, mixed_motif_graph), 1L)
+  expect_equal(
+    .g_match_motif(concrete_graph, mixed_motif_graph),
+    list(c(1L, 2L))
   )
-  expect_true(.g_have_motif(glycan_graph, generic_motif_graph))
+  expect_identical(.g_have_motif(generic_graph, mixed_motif_graph), FALSE)
+  expect_identical(
+    .g_have_motif(generic_graph, mixed_motif_graph, mode = "lenient"),
+    TRUE
+  )
 })
 
 test_that(".g_* motif functions recycle scalar match_degree like high-level API", {

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -182,37 +182,84 @@ test_that("concrete glycan and generic motif", {
 })
 
 
-test_that("generic glycan and concrete motif", {
+test_that("all-generic glycans and all-concrete motifs warn", {
   glycan <- glyrepr::o_glycan_core_2(mono_type = "generic")
   motif <- glyparse::parse_iupac_condensed("Gal(b1-3)GalNAc(?1-")
-  expect_warning(
-    expect_false(have_motif(glycan, motif)),
-    class = "warning_mismatched_structure_level"
+  expect_snapshot_warning(have_motif(glycan, motif))
+  expect_identical(suppressWarnings(have_motif(glycan, motif)), FALSE)
+
+  generic_topological <- glyrepr::remove_linkages(glycan)
+  concrete_topological <- glyrepr::remove_linkages(
+    glyrepr::o_glycan_core_2()
+  )
+  expect_snapshot_warning(
+    count_motif(generic_topological, concrete_topological)
+  )
+
+  glycans <- c(first = glycan, second = glycan)
+  motifs <- glyparse::parse_iupac_condensed(c(
+    first = "Gal(b1-3)GalNAc(?1-",
+    second = "Gal(b1-4)GalNAc(?1-"
+  ))
+  expect_snapshot_warning(have_motifs(glycans, motifs))
+  expect_identical(
+    unname(suppressWarnings(have_motifs(glycans, motifs))),
+    matrix(FALSE, nrow = 2L, ncol = 2L)
   )
 })
 
-test_that("mismatched structure levels warn before returning no matches", {
+test_that("all-topological glycans and higher-level motifs warn", {
   intact <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
   partial <- glyrepr::as_glycan_structure("Gal(b1-?)GalNAc(a1-")
-  topological <- glyrepr::reduce_structure_level(intact, "topological")
-  basic <- glyrepr::reduce_structure_level(intact, "basic")
+  topological <- glyrepr::remove_linkages(intact)
 
   expect_no_warning(have_motif(intact, topological))
   expect_no_warning(have_motif(partial, intact))
 
-  expect_warning(
-    expect_false(have_motif(topological, intact)),
-    "See `\\?get_structure_level` for details\\.",
-    class = "warning_mismatched_structure_level"
+  expect_snapshot_warning(have_motif(topological, intact))
+  expect_identical(
+    suppressWarnings(have_motif(topological, intact)),
+    FALSE
   )
-  expect_warning(
-    expect_equal(count_motif(basic, topological), 0L),
-    class = "warning_mismatched_structure_level"
+
+  glycans <- c(first = topological, second = topological)
+  motifs <- c(intact = intact, partial = partial)
+  expect_snapshot_warning(
+    have_motifs(glycans, motifs)
   )
-  expect_warning(
-    expect_false(have_motifs(topological, c(intact, topological))[[1]]),
-    class = "warning_mismatched_structure_level"
+  expect_identical(
+    unname(suppressWarnings(have_motifs(glycans, motifs))),
+    matrix(FALSE, nrow = 2L, ncol = 2L)
   )
+
+  expect_no_warning(
+    have_motifs(
+      c(intact = intact, topological = topological),
+      c(topological = topological, intact = intact)
+    )
+  )
+})
+
+test_that("mixed motif residues keep strict and lenient matching rules", {
+  glycans <- glyrepr::as_glycan_structure(c(
+    compatible = "Gal(b1-3)GalNAc(a1-",
+    concrete_mismatch = "Gal(b1-3)GlcNAc(a1-",
+    generic_at_concrete = "Hex(b1-3)HexNAc(a1-"
+  ))
+  motif <- glyrepr::as_glycan_structure("Hex(b1-3)GalNAc(a1-")
+
+  expect_identical(
+    have_motif(glycans, motif),
+    c(compatible = TRUE, concrete_mismatch = FALSE, generic_at_concrete = FALSE)
+  )
+  expect_identical(
+    have_motif(glycans, motif, mode = "lenient"),
+    c(compatible = TRUE, concrete_mismatch = FALSE, generic_at_concrete = TRUE)
+  )
+})
+
+test_that("generic fuzzy motif residues match concrete glycans", {
+  expect_identical(have_motif("GalNAc(a1-", "Hex?NAc(a1-"), TRUE)
 })
 
 
@@ -793,7 +840,7 @@ test_that("have_motifs works with ignore_linkages", {
 
 # ========== Monosaccharide Type Matching ==========
 test_that("have_motif: concrete glycan matches generic motif", {
-  # Man (concrete) should match Hex (generic) after conversion
+  # Man (concrete) should match Hex (generic)
   expect_true(have_motif("Man(?1-", "Hex(?1-"))
   expect_true(have_motif("Gal(?1-", "Hex(?1-"))
   expect_true(have_motif("Glc(?1-", "Hex(?1-"))
@@ -801,24 +848,13 @@ test_that("have_motif: concrete glycan matches generic motif", {
 
 test_that("have_motif: generic glycan does not match concrete motif", {
   # Hex (generic) should not match Man (concrete) - names don't match
-  expect_warning(
-    expect_false(
-      have_motif("Hex(?1-", "Man(?1-")
-    ),
-    class = "warning_mismatched_structure_level"
+  expect_snapshot_warning(have_motif("Hex(?1-", "Man(?1-"))
+  result <- vapply(
+    c("Man(?1-", "Gal(?1-", "Glc(?1-"),
+    \(motif) suppressWarnings(have_motif("Hex(?1-", motif)),
+    logical(1L)
   )
-  expect_warning(
-    expect_false(
-      have_motif("Hex(?1-", "Gal(?1-")
-    ),
-    class = "warning_mismatched_structure_level"
-  )
-  expect_warning(
-    expect_false(
-      have_motif("Hex(?1-", "Glc(?1-")
-    ),
-    class = "warning_mismatched_structure_level"
-  )
+  expect_identical(unname(result), c(FALSE, FALSE, FALSE))
 })
 
 test_that("have_motif: same type matches", {
@@ -840,9 +876,27 @@ test_that("have_motif: complex structures with type conversion", {
   # Reverse should not match
   generic_glycan <- "Hex(b1-3)HexNAc(?1-"
   concrete_motif <- "Gal(b1-3)GalNAc(?1-"
-  expect_warning(
-    expect_false(have_motif(generic_glycan, concrete_motif)),
-    class = "warning_mismatched_structure_level"
+  expect_snapshot_warning(
+    have_motif(generic_glycan, concrete_motif)
+  )
+  expect_identical(
+    suppressWarnings(have_motif(generic_glycan, concrete_motif)),
+    FALSE
+  )
+})
+
+test_that("have_motifs matches mixed glycans residue by residue", {
+  glycan <- "Hex(b1-3)GalNAc(a1-"
+  motifs <- c(
+    "Hex(b1-3)HexNAc(a1-",
+    "Gal(b1-3)GalNAc(a1-",
+    "Hex(b1-3)GalNAc(a1-",
+    "Gal(b1-3)HexNAc(a1-"
+  )
+
+  expect_identical(
+    unname(have_motifs(glycan, motifs)[1, ]),
+    c(TRUE, FALSE, TRUE, FALSE)
   )
 })
 
@@ -867,7 +921,6 @@ test_that("have_motif: vectorized glycans with single motif", {
 })
 
 test_that("have_motif works for repeated glycans", {
-  # This is to test the internal `fast_convert_to_generic` function.
   glycans <- c("Man(??-", "Man(??-", "Gal(??-", "Gal(??-", "GlcNAc(??-")
   motif <- "Hex(??-"
 

--- a/tests/testthat/test-igraph-utils.R
+++ b/tests/testthat/test-igraph-utils.R
@@ -63,33 +63,27 @@ test_that("integer VF2 mappings preserve mapping order", {
 })
 
 test_that("structure levels preserve glyrepr classifications", {
-  structures <- list(
-    intact = glyparse::auto_parse("Gal(b1-3)GalNAc(a1-"),
-    partial = glyparse::auto_parse("Gal(b1-?)GalNAc(a1-"),
-    topological = glyparse::auto_parse("Gal(??-?)GalNAc(??-"),
-    basic = glyparse::auto_parse("Hex(??-?)HexNAc(??-")
-  )
+  structures <- glyrepr::as_glycan_structure(c(
+    intact = "Gal(b1-3)GalNAc(a1-",
+    partial = "Gal(b1-?)GalNAc(a1-",
+    topological = "Hex(??-?)HexNAc(??-",
+    mixed = "Hex(b1-3)GalNAc(a1-",
+    missing = NA_character_
+  ))
 
-  expected <- vapply(
-    structures,
-    \(structure) suppressWarnings(glyrepr::get_structure_level(structure)),
-    character(1L)
-  )
-  actual <- vapply(structures, structure_level, character(1L))
-
-  expect_identical(actual, expected)
   expect_identical(
-    structure_level(c(structures$intact, structures$topological)),
-    suppressWarnings(
-      glyrepr::get_structure_level(
-        c(structures$intact, structures$topological)
-      )
-    )
+    structure_mono_type(structures),
+    glyrepr::get_mono_type(structures)
   )
   expect_identical(
-    structure_level(glyrepr::glycan_structure()),
-    NA_character_
+    structure_level(structures),
+    glyrepr::get_structure_level(structures)
   )
+  expect_identical(
+    structure_mono_type(glyrepr::glycan_structure()),
+    character()
+  )
+  expect_identical(structure_level(glyrepr::glycan_structure()), character())
 })
 
 test_that("repeated matching does not retain graph weak references", {

--- a/tests/testthat/test-match-batch.R
+++ b/tests/testthat/test-match-batch.R
@@ -43,6 +43,64 @@ test_that("batch motif functions restore repeated and missing glycans", {
   expect_identical(match_motifs(glycans, motifs), expected_match)
 })
 
+test_that("batch motif functions match heterogeneous vectors element-wise", {
+  glycans <- glyrepr::as_glycan_structure(c(
+    concrete = "Gal(b1-3)GalNAc(a1-",
+    mixed = "Hex(b1-3)GalNAc(a1-",
+    generic = "Hex(b1-3)HexNAc(a1-",
+    missing = NA_character_,
+    concrete_copy = "Gal(b1-3)GalNAc(a1-"
+  ))
+  motifs <- glyrepr::as_glycan_structure(c(
+    generic = "Hex(b1-3)HexNAc(a1-",
+    concrete = "Gal(b1-3)GalNAc(a1-",
+    mixed = "Hex(b1-3)GalNAc(a1-"
+  ))
+  expected_have <- rbind(
+    concrete = c(generic = TRUE, concrete = TRUE, mixed = TRUE),
+    mixed = c(generic = TRUE, concrete = FALSE, mixed = TRUE),
+    generic = c(generic = TRUE, concrete = FALSE, mixed = FALSE),
+    missing = c(generic = NA, concrete = NA, mixed = NA),
+    concrete_copy = c(generic = TRUE, concrete = TRUE, mixed = TRUE)
+  )
+  expected_count <- expected_have
+  storage.mode(expected_count) <- "integer"
+
+  matches <- match_motifs(glycans, motifs)
+  match_counts <- vapply(
+    matches,
+    function(motif_matches) {
+      vapply(
+        motif_matches,
+        \(x) if (is.null(x)) NA_integer_ else length(x),
+        integer(1L)
+      )
+    },
+    integer(length(glycans))
+  )
+  dimnames(match_counts) <- dimnames(expected_count)
+
+  expect_identical(have_motifs(glycans, motifs), expected_have)
+  expect_identical(count_motifs(glycans, motifs), expected_count)
+  expect_identical(match_counts, expected_count)
+  expect_identical(names(matches), names(motifs))
+  expect_identical(
+    unname(lapply(matches, names)),
+    rep(list(names(glycans)), length(motifs))
+  )
+
+  reversed <- motifs[3:1]
+  expect_identical(
+    have_motifs(glycans, reversed),
+    expected_have[, 3:1, drop = FALSE]
+  )
+  expect_identical(
+    count_motifs(glycans, reversed),
+    expected_count[, 3:1, drop = FALSE]
+  )
+  expect_identical(match_motifs(glycans, reversed), matches[3:1])
+})
+
 test_that("batch motif functions preserve empty glycan shapes", {
   glycans <- glyrepr::glycan_structure()
   motifs <- glyparse::parse_iupac_condensed(c(


### PR DESCRIPTION
## Summary

- Support mixed generic and concrete residues across scalar, batch, and graph-level motif matching while preserving strict asymmetric and lenient bidirectional compatibility.
- Compute monosaccharide types and structure levels element-wise, select safe motif pruning per motif, and warn for uniformly incompatible input vectors.
- Append concrete cores to concrete extracted branches and generic cores to generic or mixed branches.
- Require glyrepr >= 0.14.0.9000 and document the mixed-branch core convention.

## Verification

- `air format .`
- Full test suite against the sibling development glyrepr checkout: 573 passed
- `devtools::check()`: 0 errors, 0 warnings, 1 environment-only clock NOTE
- `pkgdown::check_pkgdown()`: no problems
- `git diff --check`
