### PR TITLE
feat: support unresolved floating glycans in motif matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 
 ## New features
 
-* `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants now support glycans with unresolved floating parts and substituents; `strict_floating` selects all-localization or any-localization aggregation for logical and count results.
+* `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants now support glycans with unresolved floating parts and substituents; `strict_floating` selects all-localization or any-localization aggregation for logical and count results. (#56)
 
-* `.g_have_motif()`, `.g_count_motif()`, and `.g_match_motif()` now support unresolved floating parts and substituents in graph inputs while preserving original node indices in returned mappings.
+* `.g_have_motif()`, `.g_count_motif()`, and `.g_match_motif()` now support unresolved floating parts and substituents in graph inputs while preserving original node indices in returned mappings. (#56)
 
 * Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics. (#55)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 
 ## New features
 
-* `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants now support glycans with unresolved floating parts; `strict_floating` selects all-localization or any-localization aggregation for logical and count results.
+* `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants now support glycans with unresolved floating parts and substituents; `strict_floating` selects all-localization or any-localization aggregation for logical and count results.
 
-* `.g_have_motif()`, `.g_count_motif()`, and `.g_match_motif()` now support unresolved floating parts in graph inputs while preserving original node indices in returned mappings.
+* `.g_have_motif()`, `.g_count_motif()`, and `.g_match_motif()` now support unresolved floating parts and substituents in graph inputs while preserving original node indices in returned mappings.
 
 * Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics. (#55)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants now support glycans with unresolved floating parts; `strict_floating` selects all-localization or any-localization aggregation for logical and count results.
+
 * Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics. (#55)
 
 # glymotif 0.18.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants now support glycans with unresolved floating parts; `strict_floating` selects all-localization or any-localization aggregation for logical and count results.
 
+* `.g_have_motif()`, `.g_count_motif()`, and `.g_match_motif()` now support unresolved floating parts in graph inputs while preserving original node indices in returned mappings.
+
 * Motif matching and branch extraction now support mixed generic and concrete residues within structures and across vectors, using residue-wise matching semantics. (#55)
 
 # glymotif 0.18.1

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -9,7 +9,7 @@
 #' @inheritParams have_motif
 #'
 #' @inheritSection have_motif About Names
-#' @inheritSection have_motif Floating parts
+#' @inheritSection have_motif Floating parts and substituents
 #'
 #' @details
 #' This function actually perform v2f algorithm to get all possible matches

--- a/R/count-motif.R
+++ b/R/count-motif.R
@@ -9,6 +9,7 @@
 #' @inheritParams have_motif
 #'
 #' @inheritSection have_motif About Names
+#' @inheritSection have_motif Floating parts
 #'
 #' @details
 #' This function actually perform v2f algorithm to get all possible matches
@@ -93,7 +94,8 @@ count_motif <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 ) {
   rlang::check_dots_empty()
 
@@ -108,7 +110,8 @@ count_motif <- function(
     match_degree = match_degree,
     single_motif = TRUE,
     strict_sub = strict_sub,
-    mode = mode
+    mode = mode,
+    strict_floating = strict_floating
   )
   result <- rlang::exec("count_motif_", !!!params)
 
@@ -130,7 +133,8 @@ count_motifs <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 ) {
   rlang::check_dots_empty()
 
@@ -142,7 +146,8 @@ count_motifs <- function(
     match_degree = match_degree,
     single_motif = FALSE,
     strict_sub = strict_sub,
-    mode = mode
+    mode = mode,
+    strict_floating = strict_floating
   )
   glycan_names <- prepare_struc_names(glycans, params$glycans)
   # Use names from resolved motifs if available (e.g., from dynamic_motifs/branch_motifs)
@@ -179,7 +184,8 @@ count_motif_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  strict_floating = TRUE
 ) {
   # This function is a simpler version of `count_motif()`.
   # It performs the logic directly without argument validations and conversions.
@@ -192,8 +198,10 @@ count_motif_ <- function(
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
     single_glycan_func = .count_motif_single,
-    smap_func = glyrepr::smap_int
+    smap_func = glyrepr::smap_int,
+    result_type = "integer"
   )
 }
 
@@ -323,7 +331,8 @@ count_motifs_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  strict_floating = TRUE
 ) {
   apply_motifs_to_glycans(
     glycans = glycans,
@@ -336,6 +345,7 @@ count_motifs_ <- function(
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
     result_type = "integer"
   )
 }

--- a/R/floating-parts.R
+++ b/R/floating-parts.R
@@ -9,64 +9,15 @@ floating_localization_graphs <- function(structure, graph) {
     return(list(graph))
   }
 
+  localizations <- glyrepr::enumerate_floating_localizations(
+    structure,
+    max_variants = .max_floating_localizations,
+    deduplicate = FALSE
+  )
   candidate_edges <- glyrepr::structure_candidate_edges(structure)
-  candidate_domains <- split(
-    candidate_edges$from_node,
-    candidate_edges$part_id
-  )
-  combination_count <- prod(as.double(lengths(candidate_domains)))
-  if (
-    !is.finite(combination_count) ||
-      combination_count > .max_floating_localizations
-  ) {
-    cli::cli_abort(c(
-      "Floating localization count exceeds the supported limit.",
-      "x" = "The glycan has {format(combination_count, scientific = FALSE)} raw candidate combinations; the limit is {.val {(.max_floating_localizations)}}.",
-      "i" = "Localize floating parts with {.fn glyrepr::localize_floating_parts} before matching this glycan."
-    ))
-  }
-
-  combinations <- do.call(
-    expand.grid,
-    c(
-      candidate_domains,
-      list(
-        KEEP.OUT.ATTRS = FALSE,
-        stringsAsFactors = FALSE
-      )
-    )
-  )
-  assignments <- purrr::map(
-    seq_len(nrow(combinations)),
-    function(i) {
-      tibble::tibble(
-        glycan_id = rep(1L, length(candidate_domains)),
-        part_id = as.integer(names(candidate_domains)),
-        parent_node = as.integer(
-          unlist(combinations[i, , drop = FALSE])
-        )
-      )
-    }
-  )
-  valid <- purrr::map_lgl(
-    assignments,
-    function(x) {
-      tryCatch(
-        {
-          glyrepr::localize_floating_parts(structure, x)
-          TRUE
-        },
-        error = function(cnd) FALSE
-      )
-    }
-  )
-  assignments <- assignments[valid]
-  if (length(assignments) == 0L) {
-    cli::cli_abort("The glycan has no conflict-free floating localization.")
-  }
 
   purrr::map(
-    assignments,
+    localizations$assignments,
     add_floating_assignment_edges,
     graph = graph,
     candidate_edges = candidate_edges

--- a/R/floating-parts.R
+++ b/R/floating-parts.R
@@ -1,0 +1,195 @@
+has_any_floating_parts <- function(structures) {
+  any(glyrepr::has_floating_parts(structures), na.rm = TRUE)
+}
+
+.max_floating_localizations <- 256L
+
+floating_localization_graphs <- function(structure, graph) {
+  if (!isTRUE(glyrepr::has_floating_parts(structure))) {
+    return(list(graph))
+  }
+
+  candidate_edges <- glyrepr::structure_candidate_edges(structure)
+  candidate_domains <- split(
+    candidate_edges$from_node,
+    candidate_edges$part_id
+  )
+  combination_count <- prod(as.double(lengths(candidate_domains)))
+  if (
+    !is.finite(combination_count) ||
+      combination_count > .max_floating_localizations
+  ) {
+    cli::cli_abort(c(
+      "Floating localization count exceeds the supported limit.",
+      "x" = "The glycan has {format(combination_count, scientific = FALSE)} raw candidate combinations; the limit is {.val {(.max_floating_localizations)}}.",
+      "i" = "Localize floating parts with {.fn glyrepr::localize_floating_parts} before matching this glycan."
+    ))
+  }
+
+  combinations <- do.call(
+    expand.grid,
+    c(
+      candidate_domains,
+      list(
+        KEEP.OUT.ATTRS = FALSE,
+        stringsAsFactors = FALSE
+      )
+    )
+  )
+  assignments <- purrr::map(
+    seq_len(nrow(combinations)),
+    function(i) {
+      tibble::tibble(
+        glycan_id = rep(1L, length(candidate_domains)),
+        part_id = as.integer(names(candidate_domains)),
+        parent_node = as.integer(
+          unlist(combinations[i, , drop = FALSE])
+        )
+      )
+    }
+  )
+  valid <- purrr::map_lgl(
+    assignments,
+    function(x) {
+      tryCatch(
+        {
+          glyrepr::localize_floating_parts(structure, x)
+          TRUE
+        },
+        error = function(cnd) FALSE
+      )
+    }
+  )
+  assignments <- assignments[valid]
+  if (length(assignments) == 0L) {
+    cli::cli_abort("The glycan has no conflict-free floating localization.")
+  }
+
+  purrr::map(
+    assignments,
+    add_floating_assignment_edges,
+    graph = graph,
+    candidate_edges = candidate_edges
+  )
+}
+
+add_floating_assignment_edges <- function(
+  assignments,
+  graph,
+  candidate_edges
+) {
+  edge_rows <- purrr::map_int(
+    seq_len(nrow(assignments)),
+    function(i) {
+      matches <- which(
+        candidate_edges$part_id == assignments$part_id[[i]] &
+          candidate_edges$from_node == assignments$parent_node[[i]]
+      )
+      if (length(matches) != 1L) {
+        cli::cli_abort(
+          "Unable to resolve a floating-part localization edge."
+        )
+      }
+      matches
+    }
+  )
+  edges <- candidate_edges[edge_rows, , drop = FALSE]
+
+  igraph::add_edges(
+    graph,
+    as.integer(t(cbind(edges$from_node, edges$to_node))),
+    attr = list(linkage = edges$linkage)
+  )
+}
+
+map_floating_structures <- function(
+  structures,
+  .f,
+  ...,
+  result_type,
+  strict_floating,
+  localization_index = NULL
+) {
+  if (is.null(localization_index)) {
+    localization_index <- prepare_floating_graph_index(structures)
+  }
+
+  apply_one <- function(i) {
+    graphs <- localization_index$graphs[[i]]
+    variant_results <- lapply(graphs, .f, ...)
+    aggregate_floating_results(
+      variant_results,
+      result_type = result_type,
+      strict_floating = strict_floating
+    )
+  }
+
+  unique_results <- switch(
+    result_type,
+    logical = vapply(
+      seq_along(localization_index$graphs),
+      apply_one,
+      logical(1L)
+    ),
+    integer = vapply(
+      seq_along(localization_index$graphs),
+      apply_one,
+      integer(1L)
+    ),
+    list = lapply(seq_along(localization_index$graphs), apply_one)
+  )
+
+  restore_batch_results(
+    unique_results,
+    localization_index$restore,
+    result_type
+  )
+}
+
+prepare_floating_graph_index <- function(structures) {
+  index <- index_unique_structures(structures)
+  codes <- unname(as.character(structures))
+  first <- match(unique(codes[!is.na(codes)]), codes)
+  index$graphs <- purrr::map2(
+    structures[first],
+    index$graphs,
+    floating_localization_graphs
+  )
+  index
+}
+
+aggregate_floating_results <- function(
+  results,
+  result_type,
+  strict_floating
+) {
+  switch(
+    result_type,
+    logical = if (strict_floating) {
+      all(unlist(results))
+    } else {
+      any(unlist(results))
+    },
+    integer = if (strict_floating) {
+      min(unlist(results))
+    } else {
+      max(unlist(results))
+    },
+    list = unique_floating_matches(results)
+  )
+}
+
+unique_floating_matches <- function(results) {
+  matches <- unlist(results, recursive = FALSE)
+  if (length(matches) <= 1L) {
+    return(matches)
+  }
+
+  keys <- vapply(
+    matches,
+    function(x) paste(x, collapse = ","),
+    character(1L),
+    USE.NAMES = FALSE
+  )
+  unname(matches[!duplicated(keys)])
+}

--- a/R/floating-parts.R
+++ b/R/floating-parts.R
@@ -4,52 +4,39 @@ has_any_floating_parts <- function(structures) {
 
 .max_floating_localizations <- 256L
 
-floating_localization_graphs <- function(structure, graph) {
-  if (!isTRUE(glyrepr::has_floating_parts(structure))) {
+graph_has_floating_parts <- function(graph) {
+  "floating_parts" %in% igraph::graph_attr_names(graph)
+}
+
+floating_localization_graphs <- function(graph) {
+  if (!graph_has_floating_parts(graph)) {
     return(list(graph))
   }
 
-  localizations <- glyrepr::enumerate_floating_localizations(
-    structure,
-    max_variants = .max_floating_localizations,
-    deduplicate = FALSE
-  )
-  candidate_edges <- glyrepr::structure_candidate_edges(structure)
-
-  purrr::map(
-    localizations$assignments,
-    add_floating_assignment_edges,
-    graph = graph,
-    candidate_edges = candidate_edges
-  )
+  glyrepr::enumerate_floating_graph_localizations(
+    graph,
+    max_variants = .max_floating_localizations
+  )$graph
 }
 
-add_floating_assignment_edges <- function(
-  assignments,
+aggregate_floating_graph_results <- function(
   graph,
-  candidate_edges
+  .f,
+  result_type,
+  strict_floating
 ) {
-  edge_rows <- purrr::map_int(
-    seq_len(nrow(assignments)),
-    function(i) {
-      matches <- which(
-        candidate_edges$part_id == assignments$part_id[[i]] &
-          candidate_edges$from_node == assignments$parent_node[[i]]
-      )
-      if (length(matches) != 1L) {
-        cli::cli_abort(
-          "Unable to resolve a floating-part localization edge."
-        )
-      }
-      matches
-    }
-  )
-  edges <- candidate_edges[edge_rows, , drop = FALSE]
+  if (!graph_has_floating_parts(graph)) {
+    return(.f(graph))
+  }
 
-  igraph::add_edges(
-    graph,
-    as.integer(t(cbind(edges$from_node, edges$to_node))),
-    attr = list(linkage = edges$linkage)
+  results <- lapply(
+    floating_localization_graphs(graph),
+    .f
+  )
+  aggregate_floating_results(
+    results,
+    result_type = result_type,
+    strict_floating = strict_floating
   )
 }
 
@@ -99,13 +86,7 @@ map_floating_structures <- function(
 
 prepare_floating_graph_index <- function(structures) {
   index <- index_unique_structures(structures)
-  codes <- unname(as.character(structures))
-  first <- match(unique(codes[!is.na(codes)]), codes)
-  index$graphs <- purrr::map2(
-    structures[first],
-    index$graphs,
-    floating_localization_graphs
-  )
+  index$graphs <- purrr::map(index$graphs, floating_localization_graphs)
   index
 }
 

--- a/R/floating-parts.R
+++ b/R/floating-parts.R
@@ -1,15 +1,20 @@
-has_any_floating_parts <- function(structures) {
-  any(glyrepr::has_floating_parts(structures), na.rm = TRUE)
+has_any_floating_metadata <- function(structures) {
+  has_floating <- glyrepr::has_floating_parts(structures) |
+    glyrepr::has_floating_substituents(structures)
+  any(has_floating, na.rm = TRUE)
 }
 
 .max_floating_localizations <- 256L
 
-graph_has_floating_parts <- function(graph) {
-  "floating_parts" %in% igraph::graph_attr_names(graph)
+graph_has_floating_metadata <- function(graph) {
+  any(
+    c("floating_parts", "floating_substituents") %in%
+      igraph::graph_attr_names(graph)
+  )
 }
 
 floating_localization_graphs <- function(graph) {
-  if (!graph_has_floating_parts(graph)) {
+  if (!graph_has_floating_metadata(graph)) {
     return(list(graph))
   }
 
@@ -25,7 +30,7 @@ aggregate_floating_graph_results <- function(
   result_type,
   strict_floating
 ) {
-  if (!graph_has_floating_parts(graph)) {
+  if (!graph_has_floating_metadata(graph)) {
     return(.f(graph))
   }
 

--- a/R/g-motif.R
+++ b/R/g-motif.R
@@ -20,6 +20,11 @@
 #' @param mode Matching mode. `"strict"` preserves the default behavior;
 #'   `"lenient"` treats glycan-side unknowns as compatible with more specific
 #'   motif fields.
+#' @param strict_floating A logical scalar. For `.g_have_motif()`, `TRUE`
+#'   requires the motif in every possible floating-part localization and
+#'   `FALSE` requires it in at least one. For `.g_count_motif()`, `TRUE`
+#'   returns the minimum count across localizations and `FALSE` returns the
+#'   maximum.
 #'
 #' @details
 #' These functions do no validation, parsing, naming, or graph mutation.
@@ -27,6 +32,11 @@
 #' high-level matching rules, including generic and mixed motif residues.
 #'
 #' These functions never call [glyrepr::as_glycan_structure()].
+#'
+#' Glycan graphs with unresolved floating parts are matched across all
+#' conflict-free localizations. `.g_match_motif()` returns the union of
+#' mappings from every localization, with node indices referring to the
+#' original unresolved graph.
 #'
 #' @returns
 #' - `.g_have_motif()` returns a logical scalar.
@@ -61,9 +71,11 @@ NULL
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 ) {
   rlang::check_dots_empty()
+  checkmate::assert_flag(strict_floating)
 
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
@@ -73,6 +85,8 @@ NULL
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
+    result_type = "logical",
     single_glycan_func = .have_motif_single
   )
 }
@@ -87,9 +101,11 @@ NULL
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 ) {
   rlang::check_dots_empty()
+  checkmate::assert_flag(strict_floating)
 
   apply_single_motif_to_graph(
     glycan_graph = glycan_graph,
@@ -99,6 +115,8 @@ NULL
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
+    result_type = "integer",
     single_glycan_func = .count_motif_single
   )
 }
@@ -125,6 +143,8 @@ NULL
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = TRUE,
+    result_type = "list",
     single_glycan_func = .match_motif_single
   )
 }
@@ -138,6 +158,9 @@ NULL
 #' @param strict_sub A logical scalar.
 #' @param match_degree A logical vector or `NULL`.
 #' @param mode Matching mode.
+#' @param strict_floating Whether logical and count results must hold across
+#'   every floating-part localization.
+#' @param result_type The result type used to aggregate floating localizations.
 #' @param single_glycan_func A graph-level motif matching function.
 #'
 #' @return The result from `single_glycan_func`.
@@ -150,6 +173,8 @@ apply_single_motif_to_graph <- function(
   strict_sub,
   match_degree,
   mode,
+  strict_floating,
+  result_type,
   single_glycan_func
 ) {
   mode <- rlang::arg_match(mode, c("strict", "lenient"))
@@ -160,16 +185,23 @@ apply_single_motif_to_graph <- function(
   )
   match_degree <- normalize_graph_match_degree(match_degree, motif_graph)
 
-  single_glycan_func(
-    glycan_graph = glycan_graph,
-    motif_graph = motif_graph,
-    motif_has_linkages = motif_has_linkages,
-    motif_composition_profile = motif_composition_profile,
-    alignment = alignment,
-    ignore_linkages = ignore_linkages,
-    strict_sub = strict_sub,
-    match_degree = match_degree,
-    mode = mode
+  aggregate_floating_graph_results(
+    glycan_graph,
+    function(graph) {
+      single_glycan_func(
+        glycan_graph = graph,
+        motif_graph = motif_graph,
+        motif_has_linkages = motif_has_linkages,
+        motif_composition_profile = motif_composition_profile,
+        alignment = alignment,
+        ignore_linkages = ignore_linkages,
+        strict_sub = strict_sub,
+        match_degree = match_degree,
+        mode = mode
+      )
+    },
+    result_type = result_type,
+    strict_floating = strict_floating
   )
 }
 

--- a/R/g-motif.R
+++ b/R/g-motif.R
@@ -21,7 +21,7 @@
 #'   `"lenient"` treats glycan-side unknowns as compatible with more specific
 #'   motif fields.
 #' @param strict_floating A logical scalar. For `.g_have_motif()`, `TRUE`
-#'   requires the motif in every possible floating-part localization and
+#'   requires the motif in every possible floating localization and
 #'   `FALSE` requires it in at least one. For `.g_count_motif()`, `TRUE`
 #'   returns the minimum count across localizations and `FALSE` returns the
 #'   maximum.
@@ -33,9 +33,9 @@
 #'
 #' These functions never call [glyrepr::as_glycan_structure()].
 #'
-#' Glycan graphs with unresolved floating parts are matched across all
-#' conflict-free localizations. `.g_match_motif()` returns the union of
-#' mappings from every localization, with node indices referring to the
+#' Glycan graphs with unresolved floating parts or substituents are matched
+#' across all conflict-free localizations. `.g_match_motif()` returns the union
+#' of mappings from every localization, with node indices referring to the
 #' original unresolved graph.
 #'
 #' @returns
@@ -159,7 +159,7 @@ NULL
 #' @param match_degree A logical vector or `NULL`.
 #' @param mode Matching mode.
 #' @param strict_floating Whether logical and count results must hold across
-#'   every floating-part localization.
+#'   every floating localization.
 #' @param result_type The result type used to aggregate floating localizations.
 #' @param single_glycan_func A graph-level motif matching function.
 #'

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -86,10 +86,10 @@
 #' Concrete mismatches still fail: for example,
 #' glycan "Gal(?1-6)GalNAc(a1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 #'
-#' # Floating parts
+#' # Floating parts and substituents
 #'
-#' Glycans with unresolved floating parts are matched across every
-#' conflict-free localization allowed by their candidate-parent domains.
+#' Glycans with unresolved floating parts or substituents are matched across
+#' every conflict-free localization allowed by their candidate-parent domains.
 #' `strict_floating = TRUE` requires a match in every localization, while
 #' `strict_floating = FALSE` requires a match in at least one localization.
 #' This setting is independent of `mode`, which controls residue and linkage
@@ -102,11 +102,11 @@
 #' structure.
 #'
 #' Motifs must be connected structures and therefore cannot themselves contain
-#' unresolved floating parts.
+#' unresolved floating parts or substituents.
 #'
 #' Matching supports up to 256 raw candidate-parent combinations per glycan.
-#' Localize floating parts with [glyrepr::localize_floating_parts()] first for
-#' larger domains.
+#' Localize floating parts and substituents with
+#' [glyrepr::localize_floating_parts()] first for larger domains.
 #'
 #' # Alignment
 #'
@@ -232,8 +232,8 @@
 #'   rejecting concrete mismatches.
 #' @param strict_floating A logical value. If `TRUE` (default), a motif is
 #'   present only when it occurs in every conflict-free localization of any
-#'   floating glycan parts. If `FALSE`, a motif is present when it occurs in at
-#'   least one possible localization.
+#'   floating glycan parts or substituents. If `FALSE`, a motif is present when
+#'   it occurs in at least one possible localization.
 #'
 #' @returns
 #' - `have_motif()`: A logical vector indicating if each `glycan` has the `motif`.

--- a/R/have-motif.R
+++ b/R/have-motif.R
@@ -86,6 +86,28 @@
 #' Concrete mismatches still fail: for example,
 #' glycan "Gal(?1-6)GalNAc(a1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 #'
+#' # Floating parts
+#'
+#' Glycans with unresolved floating parts are matched across every
+#' conflict-free localization allowed by their candidate-parent domains.
+#' `strict_floating = TRUE` requires a match in every localization, while
+#' `strict_floating = FALSE` requires a match in at least one localization.
+#' This setting is independent of `mode`, which controls residue and linkage
+#' obscurity.
+#'
+#' [count_motif()] and [count_motifs()] return the minimum count across
+#' localizations in strict-floating mode and the maximum count otherwise.
+#' [match_motif()] and [match_motifs()] return the union of node mappings from
+#' every localization, using node indices from the original unresolved
+#' structure.
+#'
+#' Motifs must be connected structures and therefore cannot themselves contain
+#' unresolved floating parts.
+#'
+#' Matching supports up to 256 raw candidate-parent combinations per glycan.
+#' Localize floating parts with [glyrepr::localize_floating_parts()] first for
+#' larger domains.
+#'
 #' # Alignment
 #'
 #' According to the [GlycoMotif](https://glycomotif.glyomics.org) database,
@@ -208,6 +230,10 @@
 #'   glycans cannot be more obscure than motifs. `"lenient"` treats glycan-side
 #'   obscure fields as compatible with more specific motif fields while still
 #'   rejecting concrete mismatches.
+#' @param strict_floating A logical value. If `TRUE` (default), a motif is
+#'   present only when it occurs in every conflict-free localization of any
+#'   floating glycan parts. If `FALSE`, a motif is present when it occurs in at
+#'   least one possible localization.
 #'
 #' @returns
 #' - `have_motif()`: A logical vector indicating if each `glycan` has the `motif`.
@@ -313,7 +339,8 @@ have_motif <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 ) {
   rlang::check_dots_empty()
 
@@ -328,7 +355,8 @@ have_motif <- function(
     match_degree = match_degree,
     single_motif = TRUE,
     strict_sub = strict_sub,
-    mode = mode
+    mode = mode,
+    strict_floating = strict_floating
   )
   result <- rlang::exec("have_motif_", !!!params)
 
@@ -350,7 +378,8 @@ have_motifs <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 ) {
   rlang::check_dots_empty()
 
@@ -362,7 +391,8 @@ have_motifs <- function(
     match_degree = match_degree,
     single_motif = FALSE,
     strict_sub = strict_sub,
-    mode = mode
+    mode = mode,
+    strict_floating = strict_floating
   )
   glycan_names <- prepare_struc_names(glycans, params$glycans)
   # Use names from resolved motifs if available (e.g., from dynamic_motifs/branch_motifs)
@@ -398,7 +428,8 @@ have_motif_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  strict_floating = TRUE
 ) {
   # This function is a simpler version of `have_motif()`.
   # It performs the logic directly without argument validations and conversions.
@@ -411,8 +442,10 @@ have_motif_ <- function(
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
     single_glycan_func = .have_motif_single,
-    smap_func = glyrepr::smap_lgl
+    smap_func = glyrepr::smap_lgl,
+    result_type = "logical"
   )
 }
 
@@ -551,7 +584,8 @@ have_motifs_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  strict_floating = TRUE
 ) {
   apply_motifs_to_glycans(
     glycans = glycans,
@@ -564,6 +598,7 @@ have_motifs_ <- function(
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
     result_type = "logical"
   )
 }

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -45,6 +45,20 @@
 #' and the inner lists are named by glycans,
 #' following the same rules as in `have_motifs()` and `count_motifs()`.
 #'
+#' # Floating parts
+#'
+#' Glycans with unresolved floating parts are matched across every
+#' conflict-free localization allowed by their candidate-parent domains. These
+#' functions return the union of node mappings from every localization, using
+#' node indices from the original unresolved structure.
+#'
+#' Motifs must be connected structures and therefore cannot themselves contain
+#' unresolved floating parts.
+#'
+#' Matching supports up to 256 raw candidate-parent combinations per glycan.
+#' Localize floating parts with [glyrepr::localize_floating_parts()] first for
+#' larger domains.
+#'
 #' @inheritParams have_motif
 #'
 #' @returns
@@ -215,7 +229,8 @@ match_motif_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  strict_floating = TRUE
 ) {
   apply_single_motif_to_glycans(
     glycans = glycans,
@@ -225,8 +240,10 @@ match_motif_ <- function(
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
     single_glycan_func = .match_motif_single,
-    smap_func = glyrepr::smap
+    smap_func = glyrepr::smap,
+    result_type = "list"
   )
 }
 
@@ -249,7 +266,8 @@ match_motifs_ <- function(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = "strict"
+  mode = "strict",
+  strict_floating = TRUE
 ) {
   match_degree_list <- if (is.null(match_degree)) {
     rep(list(NULL), length(motifs))
@@ -268,6 +286,7 @@ match_motifs_ <- function(
     strict_sub = strict_sub,
     match_degree = match_degree_list,
     mode = mode,
+    strict_floating = strict_floating,
     result_type = "list"
   )
 }

--- a/R/match-motif.R
+++ b/R/match-motif.R
@@ -45,19 +45,19 @@
 #' and the inner lists are named by glycans,
 #' following the same rules as in `have_motifs()` and `count_motifs()`.
 #'
-#' # Floating parts
+#' # Floating parts and substituents
 #'
-#' Glycans with unresolved floating parts are matched across every
-#' conflict-free localization allowed by their candidate-parent domains. These
-#' functions return the union of node mappings from every localization, using
-#' node indices from the original unresolved structure.
+#' Glycans with unresolved floating parts or substituents are matched across
+#' every conflict-free localization allowed by their candidate-parent domains.
+#' These functions return the union of node mappings from every localization,
+#' using node indices from the original unresolved structure.
 #'
 #' Motifs must be connected structures and therefore cannot themselves contain
-#' unresolved floating parts.
+#' unresolved floating parts or substituents.
 #'
 #' Matching supports up to 256 raw candidate-parent combinations per glycan.
-#' Localize floating parts with [glyrepr::localize_floating_parts()] first for
-#' larger domains.
+#' Localize floating parts and substituents with
+#' [glyrepr::localize_floating_parts()] first for larger domains.
 #'
 #' @inheritParams have_motif
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,8 +12,8 @@
 #' @param single_motif Whether the caller expects exactly one motif.
 #' @param strict_sub Whether substituent matching should be strict.
 #' @param mode Matching mode.
-#' @param strict_floating Whether floating-part matches must hold across every
-#'   possible localization.
+#' @param strict_floating Whether matches involving floating parts or
+#'   substituents must hold across every possible localization.
 #' @param call The call environment used for errors.
 #'
 #' @return A normalized argument list for single- or multiple-motif internals.
@@ -113,14 +113,14 @@ validate_no_floating_motifs <- function(
   motifs,
   call = rlang::caller_env()
 ) {
-  if (!any(glyrepr::has_floating_parts(motifs), na.rm = TRUE)) {
+  if (!has_any_floating_metadata(motifs)) {
     return(invisible(NULL))
   }
 
   cli::cli_abort(
     c(
-      "`motifs` cannot contain unresolved floating parts.",
-      "i" = "Localize floating motif parts before matching."
+      "`motifs` cannot contain unresolved floating parts or substituents.",
+      "i" = "Localize floating motif parts and substituents before matching."
     ),
     call = call
   )
@@ -763,7 +763,7 @@ apply_single_motif_to_glycans <- function(
   # single_glycan_func should be either .have_motif_single or .count_motif_single
   # smap_func should be either glyrepr::smap_lgl or glyrepr::smap_int
 
-  has_floating <- has_any_floating_parts(glycans)
+  has_floating <- has_any_floating_metadata(glycans)
   motif_graph <- glyrepr::get_structure_graphs(motif)
   motif_has_linkages <- graph_has_linkages(motif_graph)
   motif_composition_profile <- new_motif_composition_profile(
@@ -882,7 +882,7 @@ apply_motifs_to_glycans <- function(
     match_degree
   }
 
-  if (has_any_floating_parts(glycans)) {
+  if (has_any_floating_metadata(glycans)) {
     localization_index <- prepare_floating_graph_index(glycans)
     smap_func <- switch(
       result_type,

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,6 +12,8 @@
 #' @param single_motif Whether the caller expects exactly one motif.
 #' @param strict_sub Whether substituent matching should be strict.
 #' @param mode Matching mode.
+#' @param strict_floating Whether floating-part matches must hold across every
+#'   possible localization.
 #' @param call The call environment used for errors.
 #'
 #' @return A normalized argument list for single- or multiple-motif internals.
@@ -25,9 +27,11 @@ prepare_motif_args <- function(
   single_motif = FALSE,
   strict_sub = TRUE,
   mode = "strict",
+  strict_floating = TRUE,
   call = rlang::caller_env()
 ) {
   mode <- rlang::arg_match(mode, c("strict", "lenient"))
+  checkmate::assert_flag(strict_floating)
 
   prepared <- if (is_motif_spec(motifs)) {
     prepare_spec_motif_args(
@@ -74,6 +78,7 @@ prepare_motif_args <- function(
     require_scalar = single_motif,
     call = call
   )
+  validate_no_floating_motifs(motifs, call = call)
   match_degree <- validate_match_degree(
     prepared$match_degree,
     motifs,
@@ -92,7 +97,32 @@ prepare_motif_args <- function(
     strict_sub = strict_sub,
     match_degree = match_degree,
     mode = mode,
+    strict_floating = strict_floating,
     single_motif = single_motif
+  )
+}
+
+#' Validate That Motifs Are Connected Structures
+#'
+#' @param motifs A normalized motif structure vector.
+#' @param call The call environment used for errors.
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+validate_no_floating_motifs <- function(
+  motifs,
+  call = rlang::caller_env()
+) {
+  if (!any(glyrepr::has_floating_parts(motifs), na.rm = TRUE)) {
+    return(invisible(NULL))
+  }
+
+  cli::cli_abort(
+    c(
+      "`motifs` cannot contain unresolved floating parts.",
+      "i" = "Localize floating motif parts before matching."
+    ),
+    call = call
   )
 }
 
@@ -334,6 +364,7 @@ new_prepared_motif_args <- function(
   strict_sub,
   match_degree,
   mode,
+  strict_floating,
   single_motif
 ) {
   common_args <- list(
@@ -341,21 +372,38 @@ new_prepared_motif_args <- function(
     ignore_linkages = ignore_linkages,
     strict_sub = strict_sub,
     match_degree = match_degree,
-    mode = mode
+    mode = mode,
+    strict_floating = strict_floating
   )
 
   if (single_motif) {
     return(c(
       common_args["glycans"],
       list(motif = motifs, alignment = alignments),
-      common_args[c("ignore_linkages", "strict_sub", "match_degree", "mode")]
+      common_args[
+        c(
+          "ignore_linkages",
+          "strict_sub",
+          "match_degree",
+          "mode",
+          "strict_floating"
+        )
+      ]
     ))
   }
 
   c(
     common_args["glycans"],
     list(motifs = motifs, alignments = alignments),
-    common_args[c("ignore_linkages", "strict_sub", "match_degree", "mode")]
+    common_args[
+      c(
+        "ignore_linkages",
+        "strict_sub",
+        "match_degree",
+        "mode",
+        "strict_floating"
+      )
+    ]
   )
 }
 
@@ -705,30 +753,58 @@ apply_single_motif_to_glycans <- function(
   strict_sub,
   match_degree,
   mode,
+  strict_floating,
   single_glycan_func,
-  smap_func
+  smap_func,
+  result_type,
+  localization_index = NULL
 ) {
   # Generic function to apply a single motif to multiple glycans
   # single_glycan_func should be either .have_motif_single or .count_motif_single
   # smap_func should be either glyrepr::smap_lgl or glyrepr::smap_int
 
+  has_floating <- has_any_floating_parts(glycans)
   motif_graph <- glyrepr::get_structure_graphs(motif)
   motif_has_linkages <- graph_has_linkages(motif_graph)
   motif_composition_profile <- new_motif_composition_profile(
     motif_graph,
     mode = mode
   )
-  smap_func(
+  if (!has_floating) {
+    return(smap_func(
+      glycans,
+      single_glycan_func,
+      motif_graph,
+      motif_has_linkages,
+      motif_composition_profile,
+      alignment,
+      ignore_linkages,
+      strict_sub,
+      match_degree,
+      mode
+    ))
+  }
+
+  apply_one <- function(glycan_graph) {
+    single_glycan_func(
+      glycan_graph,
+      motif_graph,
+      motif_has_linkages,
+      motif_composition_profile,
+      alignment,
+      ignore_linkages,
+      strict_sub,
+      match_degree,
+      mode
+    )
+  }
+
+  map_floating_structures(
     glycans,
-    single_glycan_func,
-    motif_graph,
-    motif_has_linkages,
-    motif_composition_profile,
-    alignment,
-    ignore_linkages,
-    strict_sub,
-    match_degree,
-    mode
+    apply_one,
+    result_type = result_type,
+    strict_floating = strict_floating,
+    localization_index = localization_index
   )
 }
 
@@ -789,6 +865,7 @@ apply_motifs_to_glycans <- function(
   strict_sub,
   match_degree,
   mode,
+  strict_floating,
   result_type
 ) {
   # Generic function to apply multiple motifs to multiple glycans
@@ -805,23 +882,52 @@ apply_motifs_to_glycans <- function(
     match_degree
   }
 
-  batch <- prepare_match_batch(glycans, motifs, mode = mode)
-  motif_results_list <- lapply(
-    seq_along(motifs),
-    function(i) {
-      apply_batch_motif(
-        batch = batch,
-        motif_position = i,
-        alignment = alignments[[i]],
-        ignore_linkages = ignore_linkages,
-        strict_sub = strict_sub,
-        match_degree = match_degree_list[[i]],
-        mode = mode,
-        single_glycan_func = single_glycan_func,
-        result_type = result_type
-      )
-    }
-  )
+  if (has_any_floating_parts(glycans)) {
+    localization_index <- prepare_floating_graph_index(glycans)
+    smap_func <- switch(
+      result_type,
+      logical = glyrepr::smap_lgl,
+      integer = glyrepr::smap_int,
+      list = glyrepr::smap
+    )
+    motif_results_list <- lapply(
+      seq_along(motifs),
+      function(i) {
+        apply_single_motif_to_glycans(
+          glycans = glycans,
+          motif = motifs[i],
+          alignment = alignments[[i]],
+          ignore_linkages = ignore_linkages,
+          strict_sub = strict_sub,
+          match_degree = match_degree_list[[i]],
+          mode = mode,
+          strict_floating = strict_floating,
+          single_glycan_func = single_glycan_func,
+          smap_func = smap_func,
+          result_type = result_type,
+          localization_index = localization_index
+        )
+      }
+    )
+  } else {
+    batch <- prepare_match_batch(glycans, motifs, mode = mode)
+    motif_results_list <- lapply(
+      seq_along(motifs),
+      function(i) {
+        apply_batch_motif(
+          batch = batch,
+          motif_position = i,
+          alignment = alignments[[i]],
+          ignore_linkages = ignore_linkages,
+          strict_sub = strict_sub,
+          match_degree = match_degree_list[[i]],
+          mode = mode,
+          single_glycan_func = single_glycan_func,
+          result_type = result_type
+        )
+      }
+    )
+  }
 
   # Set names for the results if provided
   if (!is.null(motif_names)) {

--- a/man/count_motif.Rd
+++ b/man/count_motif.Rd
@@ -76,8 +76,8 @@ rejecting concrete mismatches.}
 
 \item{strict_floating}{A logical value. If \code{TRUE} (default), a motif is
 present only when it occurs in every conflict-free localization of any
-floating glycan parts. If \code{FALSE}, a motif is present when it occurs in at
-least one possible localization.}
+floating glycan parts or substituents. If \code{FALSE}, a motif is present when
+it occurs in at least one possible localization.}
 
 \item{motifs}{One of:
 \itemize{
@@ -166,9 +166,9 @@ Motif names have the following rules:
 }
 }
 
-\section{Floating parts}{
-Glycans with unresolved floating parts are matched across every
-conflict-free localization allowed by their candidate-parent domains.
+\section{Floating parts and substituents}{
+Glycans with unresolved floating parts or substituents are matched across
+every conflict-free localization allowed by their candidate-parent domains.
 \code{strict_floating = TRUE} requires a match in every localization, while
 \code{strict_floating = FALSE} requires a match in at least one localization.
 This setting is independent of \code{mode}, which controls residue and linkage
@@ -181,11 +181,11 @@ every localization, using node indices from the original unresolved
 structure.
 
 Motifs must be connected structures and therefore cannot themselves contain
-unresolved floating parts.
+unresolved floating parts or substituents.
 
 Matching supports up to 256 raw candidate-parent combinations per glycan.
-Localize floating parts with \code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for
-larger domains.
+Localize floating parts and substituents with
+\code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for larger domains.
 }
 
 \examples{

--- a/man/count_motif.Rd
+++ b/man/count_motif.Rd
@@ -13,7 +13,8 @@ count_motif(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 )
 
 count_motifs(
@@ -24,7 +25,8 @@ count_motifs(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 )
 }
 \arguments{
@@ -71,6 +73,11 @@ provided, \code{alignment} and \code{alignments} are silently ignored.}
 glycans cannot be more obscure than motifs. \code{"lenient"} treats glycan-side
 obscure fields as compatible with more specific motif fields while still
 rejecting concrete mismatches.}
+
+\item{strict_floating}{A logical value. If \code{TRUE} (default), a motif is
+present only when it occurs in every conflict-free localization of any
+floating glycan parts. If \code{FALSE}, a motif is present when it occurs in at
+least one possible localization.}
 
 \item{motifs}{One of:
 \itemize{
@@ -157,6 +164,28 @@ Motif names have the following rules:
 \item If \code{motifs} don't have names and are GGM database motif names (e.g. "N-glycan core"), use them.
 \item Otherwise, no colnames.
 }
+}
+
+\section{Floating parts}{
+Glycans with unresolved floating parts are matched across every
+conflict-free localization allowed by their candidate-parent domains.
+\code{strict_floating = TRUE} requires a match in every localization, while
+\code{strict_floating = FALSE} requires a match in at least one localization.
+This setting is independent of \code{mode}, which controls residue and linkage
+obscurity.
+
+\code{\link[=count_motif]{count_motif()}} and \code{\link[=count_motifs]{count_motifs()}} return the minimum count across
+localizations in strict-floating mode and the maximum count otherwise.
+\code{\link[=match_motif]{match_motif()}} and \code{\link[=match_motifs]{match_motifs()}} return the union of node mappings from
+every localization, using node indices from the original unresolved
+structure.
+
+Motifs must be connected structures and therefore cannot themselves contain
+unresolved floating parts.
+
+Matching supports up to 256 raw candidate-parent combinations per glycan.
+Localize floating parts with \code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for
+larger domains.
 }
 
 \examples{

--- a/man/dot-g_motif.Rd
+++ b/man/dot-g_motif.Rd
@@ -67,7 +67,7 @@ number of motif nodes.}
 motif fields.}
 
 \item{strict_floating}{A logical scalar. For \code{.g_have_motif()}, \code{TRUE}
-requires the motif in every possible floating-part localization and
+requires the motif in every possible floating localization and
 \code{FALSE} requires it in at least one. For \code{.g_count_motif()}, \code{TRUE}
 returns the minimum count across localizations and \code{FALSE} returns the
 maximum.}
@@ -91,9 +91,9 @@ high-level matching rules, including generic and mixed motif residues.
 
 These functions never call \code{\link[glyrepr:as_glycan_structure]{glyrepr::as_glycan_structure()}}.
 
-Glycan graphs with unresolved floating parts are matched across all
-conflict-free localizations. \code{.g_match_motif()} returns the union of
-mappings from every localization, with node indices referring to the
+Glycan graphs with unresolved floating parts or substituents are matched
+across all conflict-free localizations. \code{.g_match_motif()} returns the union
+of mappings from every localization, with node indices referring to the
 original unresolved graph.
 }
 \examples{

--- a/man/dot-g_motif.Rd
+++ b/man/dot-g_motif.Rd
@@ -15,7 +15,8 @@
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 )
 
 .g_count_motif(
@@ -26,7 +27,8 @@
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 )
 
 .g_match_motif(
@@ -63,6 +65,12 @@ number of motif nodes.}
 \item{mode}{Matching mode. \code{"strict"} preserves the default behavior;
 \code{"lenient"} treats glycan-side unknowns as compatible with more specific
 motif fields.}
+
+\item{strict_floating}{A logical scalar. For \code{.g_have_motif()}, \code{TRUE}
+requires the motif in every possible floating-part localization and
+\code{FALSE} requires it in at least one. For \code{.g_count_motif()}, \code{TRUE}
+returns the minimum count across localizations and \code{FALSE} returns the
+maximum.}
 }
 \value{
 \itemize{
@@ -82,6 +90,11 @@ Callers must provide valid graph objects. Residue compatibility follows the
 high-level matching rules, including generic and mixed motif residues.
 
 These functions never call \code{\link[glyrepr:as_glycan_structure]{glyrepr::as_glycan_structure()}}.
+
+Glycan graphs with unresolved floating parts are matched across all
+conflict-free localizations. \code{.g_match_motif()} returns the union of
+mappings from every localization, with node indices referring to the
+original unresolved graph.
 }
 \examples{
 library(glyparse)

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -13,7 +13,8 @@ have_motif(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 )
 
 have_motifs(
@@ -24,7 +25,8 @@ have_motifs(
   ignore_linkages = FALSE,
   strict_sub = TRUE,
   match_degree = NULL,
-  mode = c("strict", "lenient")
+  mode = c("strict", "lenient"),
+  strict_floating = TRUE
 )
 }
 \arguments{
@@ -71,6 +73,11 @@ provided, \code{alignment} and \code{alignments} are silently ignored.}
 glycans cannot be more obscure than motifs. \code{"lenient"} treats glycan-side
 obscure fields as compatible with more specific motif fields while still
 rejecting concrete mismatches.}
+
+\item{strict_floating}{A logical value. If \code{TRUE} (default), a motif is
+present only when it occurs in every conflict-free localization of any
+floating glycan parts. If \code{FALSE}, a motif is present when it occurs in at
+least one possible localization.}
 
 \item{motifs}{One of:
 \itemize{
@@ -183,6 +190,28 @@ specific motif fields. In the lenient mode,
 glycan "Gal(?1-?)GalNAc(?1-" matches motif "Gal(b1-3)GalNAc(a1-".
 Concrete mismatches still fail: for example,
 glycan "Gal(?1-6)GalNAc(a1-" does not match motif "Gal(b1-3)GalNAc(a1-".
+}
+
+\section{Floating parts}{
+Glycans with unresolved floating parts are matched across every
+conflict-free localization allowed by their candidate-parent domains.
+\code{strict_floating = TRUE} requires a match in every localization, while
+\code{strict_floating = FALSE} requires a match in at least one localization.
+This setting is independent of \code{mode}, which controls residue and linkage
+obscurity.
+
+\code{\link[=count_motif]{count_motif()}} and \code{\link[=count_motifs]{count_motifs()}} return the minimum count across
+localizations in strict-floating mode and the maximum count otherwise.
+\code{\link[=match_motif]{match_motif()}} and \code{\link[=match_motifs]{match_motifs()}} return the union of node mappings from
+every localization, using node indices from the original unresolved
+structure.
+
+Motifs must be connected structures and therefore cannot themselves contain
+unresolved floating parts.
+
+Matching supports up to 256 raw candidate-parent combinations per glycan.
+Localize floating parts with \code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for
+larger domains.
 }
 
 \section{Alignment}{

--- a/man/have_motif.Rd
+++ b/man/have_motif.Rd
@@ -76,8 +76,8 @@ rejecting concrete mismatches.}
 
 \item{strict_floating}{A logical value. If \code{TRUE} (default), a motif is
 present only when it occurs in every conflict-free localization of any
-floating glycan parts. If \code{FALSE}, a motif is present when it occurs in at
-least one possible localization.}
+floating glycan parts or substituents. If \code{FALSE}, a motif is present when
+it occurs in at least one possible localization.}
 
 \item{motifs}{One of:
 \itemize{
@@ -192,9 +192,9 @@ Concrete mismatches still fail: for example,
 glycan "Gal(?1-6)GalNAc(a1-" does not match motif "Gal(b1-3)GalNAc(a1-".
 }
 
-\section{Floating parts}{
-Glycans with unresolved floating parts are matched across every
-conflict-free localization allowed by their candidate-parent domains.
+\section{Floating parts and substituents}{
+Glycans with unresolved floating parts or substituents are matched across
+every conflict-free localization allowed by their candidate-parent domains.
 \code{strict_floating = TRUE} requires a match in every localization, while
 \code{strict_floating = FALSE} requires a match in at least one localization.
 This setting is independent of \code{mode}, which controls residue and linkage
@@ -207,11 +207,11 @@ every localization, using node indices from the original unresolved
 structure.
 
 Motifs must be connected structures and therefore cannot themselves contain
-unresolved floating parts.
+unresolved floating parts or substituents.
 
 Matching supports up to 256 raw candidate-parent combinations per glycan.
-Localize floating parts with \code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for
-larger domains.
+Localize floating parts and substituents with
+\code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for larger domains.
 }
 
 \section{Alignment}{

--- a/man/match_motif.Rd
+++ b/man/match_motif.Rd
@@ -145,6 +145,20 @@ and the inner lists are named by glycans,
 following the same rules as in \code{have_motifs()} and \code{count_motifs()}.
 }
 
+\section{Floating parts}{
+Glycans with unresolved floating parts are matched across every
+conflict-free localization allowed by their candidate-parent domains. These
+functions return the union of node mappings from every localization, using
+node indices from the original unresolved structure.
+
+Motifs must be connected structures and therefore cannot themselves contain
+unresolved floating parts.
+
+Matching supports up to 256 raw candidate-parent combinations per glycan.
+Localize floating parts with \code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for
+larger domains.
+}
+
 \examples{
 library(glyparse)
 library(glyrepr)

--- a/man/match_motif.Rd
+++ b/man/match_motif.Rd
@@ -145,18 +145,18 @@ and the inner lists are named by glycans,
 following the same rules as in \code{have_motifs()} and \code{count_motifs()}.
 }
 
-\section{Floating parts}{
-Glycans with unresolved floating parts are matched across every
-conflict-free localization allowed by their candidate-parent domains. These
-functions return the union of node mappings from every localization, using
-node indices from the original unresolved structure.
+\section{Floating parts and substituents}{
+Glycans with unresolved floating parts or substituents are matched across
+every conflict-free localization allowed by their candidate-parent domains.
+These functions return the union of node mappings from every localization,
+using node indices from the original unresolved structure.
 
 Motifs must be connected structures and therefore cannot themselves contain
-unresolved floating parts.
+unresolved floating parts or substituents.
 
 Matching supports up to 256 raw candidate-parent combinations per glycan.
-Localize floating parts with \code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for
-larger domains.
+Localize floating parts and substituents with
+\code{\link[glyrepr:localize_floating_parts]{glyrepr::localize_floating_parts()}} first for larger domains.
 }
 
 \examples{

--- a/tests/testthat/_snaps/have-motif.md
+++ b/tests/testthat/_snaps/have-motif.md
@@ -37,3 +37,11 @@
     Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
     i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
 
+# floating motifs are rejected clearly
+
+    Code
+      have_motif("Gal(a1-3)Man(a1-", "{Gal(a1-3)}Man(a1-3)GlcNAc(b1-")
+    Condition
+      Error in `have_motif()`:
+      ! `motifs` cannot contain unresolved floating parts.
+      i Localize floating motif parts before matching.

--- a/tests/testthat/_snaps/have-motif.md
+++ b/tests/testthat/_snaps/have-motif.md
@@ -37,11 +37,20 @@
     Matching generic `glycans` against concrete `motifs` always returns no matches in strict mode.
     i Convert motifs with `glyrepr::convert_to_generic()`, or use `mode = "lenient"` when generic identities should match their concrete counterparts.
 
-# floating motifs are rejected clearly
+# floating parts in motifs are rejected clearly
 
     Code
       have_motif("Gal(a1-3)Man(a1-", "{Gal(a1-3)}Man(a1-3)GlcNAc(b1-")
     Condition
       Error in `have_motif()`:
-      ! `motifs` cannot contain unresolved floating parts.
-      i Localize floating motif parts before matching.
+      ! `motifs` cannot contain unresolved floating parts or substituents.
+      i Localize floating motif parts and substituents before matching.
+
+# floating substituents in motifs are rejected clearly
+
+    Code
+      have_motif("Gal6S(a1-3)Glc(a1-", "{6S}Gal(a1-3)Glc(a1-")
+    Condition
+      Error in `have_motif()`:
+      ! `motifs` cannot contain unresolved floating parts or substituents.
+      i Localize floating motif parts and substituents before matching.

--- a/tests/testthat/test-count-motif.R
+++ b/tests/testthat/test-count-motif.R
@@ -402,8 +402,8 @@ test_that("count_motif supports lenient mode", {
 test_that("count_motif supports floating parts", {
   motif <- "Gal(a1-3)Man(a1-"
   glycan <- c(
-    "{Gal(a1-3)|1,2}{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",
-    "{Gal(a1-4)|1,2}{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+    "{Gal(a1-3)|3,4}{Gal(a1-3)|3,4}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",
+    "{Gal(a1-4)|3,4}{Gal(a1-3)|3,4}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
   )
   expect_identical(count_motif(glycan, motif), c(2L, 1L))
 })

--- a/tests/testthat/test-count-motif.R
+++ b/tests/testthat/test-count-motif.R
@@ -398,7 +398,7 @@ test_that("count_motif supports lenient mode", {
   expect_equal(count_motif(glycan, motif, mode = "lenient"), 1L)
 })
 
-# ========== Floating Parts ==========
+# ========== Floating Structures ==========
 test_that("count_motif supports floating parts", {
   motif <- "Gal(a1-3)Man(a1-"
   glycan <- c(
@@ -436,5 +436,22 @@ test_that("count_motifs aggregates floating localizations per motif", {
   expect_identical(
     unname(count_motifs(glycan, motifs, strict_floating = FALSE)),
     matrix(c(2L, 2L), nrow = 1L)
+  )
+})
+
+test_that("count_motif aggregates floating substituent localizations", {
+  glycans <- glyrepr::as_glycan_structure(c(
+    floating = "{6S}Gal(a1-3)Glc(a1-",
+    ordinary = "Gal6S(a1-3)Glc(a1-"
+  ))
+  motif <- glyrepr::as_glycan_structure("Gal6S(a1-")
+
+  expect_identical(
+    count_motif(glycans, motif, strict_floating = TRUE),
+    c(floating = 0L, ordinary = 1L)
+  )
+  expect_identical(
+    count_motif(glycans, motif, strict_floating = FALSE),
+    c(floating = 1L, ordinary = 1L)
   )
 })

--- a/tests/testthat/test-count-motif.R
+++ b/tests/testthat/test-count-motif.R
@@ -418,6 +418,23 @@ test_that("count_motif differs strict and lenient floating modes", {
   motif <- "Gal(??-?)GlcNAc(??-?)Gal(??-"
   glycan <- "{Gal(??-?)GlcNAc(??-?)}Gal(??-?)GlcNAc(??-?)Gal(??-"
 
-  expect_identical(have_motif(glycan, motif, strict_floating = TRUE), 1L)
-  expect_identical(have_motif(glycan, motif, strict_floating = FALSE), 2L)
+  expect_identical(count_motif(glycan, motif, strict_floating = TRUE), 1L)
+  expect_identical(count_motif(glycan, motif, strict_floating = FALSE), 2L)
+})
+
+test_that("count_motifs aggregates floating localizations per motif", {
+  glycan <- "{Gal(??-?)GlcNAc(??-?)}Gal(??-?)GlcNAc(??-?)Gal(??-"
+  motifs <- c(
+    trisaccharide = "Gal(??-?)GlcNAc(??-?)Gal(??-",
+    disaccharide = "Gal(??-?)GlcNAc(??-"
+  )
+
+  expect_identical(
+    unname(count_motifs(glycan, motifs, strict_floating = TRUE)),
+    matrix(c(1L, 2L), nrow = 1L)
+  )
+  expect_identical(
+    unname(count_motifs(glycan, motifs, strict_floating = FALSE)),
+    matrix(c(2L, 2L), nrow = 1L)
+  )
 })

--- a/tests/testthat/test-count-motif.R
+++ b/tests/testthat/test-count-motif.R
@@ -397,3 +397,27 @@ test_that("count_motif supports lenient mode", {
   expect_equal(suppressWarnings(count_motif(glycan, motif)), 0L)
   expect_equal(count_motif(glycan, motif, mode = "lenient"), 1L)
 })
+
+# ========== Floating Parts ==========
+test_that("count_motif supports floating parts", {
+  motif <- "Gal(a1-3)Man(a1-"
+  glycan <- c(
+    "{Gal(a1-3)|1,2}{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",
+    "{Gal(a1-4)|1,2}{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  )
+  expect_identical(count_motif(glycan, motif), c(2L, 1L))
+})
+
+test_that("count_motif differs strict and lenient floating modes", {
+  # Similar to the rule in `have_motif()`,
+  # in the strict mode, a motif is regarded to be appeared only when
+  # it appears in every possible glycans derived from the floating parts,
+  # while in the lenient mode, a motif appears as long as it could possibly appear.
+  # In the context of `count_motif()`, this means when `strict_floating = TRUE`,
+  # we take the minimum count, and for `strict_floating = FALSE` the maximum.
+  motif <- "Gal(??-?)GlcNAc(??-?)Gal(??-"
+  glycan <- "{Gal(??-?)GlcNAc(??-?)}Gal(??-?)GlcNAc(??-?)Gal(??-"
+
+  expect_identical(have_motif(glycan, motif, strict_floating = TRUE), 1L)
+  expect_identical(have_motif(glycan, motif, strict_floating = FALSE), 2L)
+})

--- a/tests/testthat/test-g-motif.R
+++ b/tests/testthat/test-g-motif.R
@@ -143,6 +143,36 @@ test_that(".g_* motif functions aggregate floating localizations", {
   )
 })
 
+test_that(".g_* motif functions aggregate floating substituent localizations", {
+  glycan <- glyrepr::as_glycan_structure(
+    "{6S}Gal(a1-3)Glc(a1-"
+  )
+  motif <- glyrepr::as_glycan_structure("Gal6S(a1-")
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = TRUE),
+    FALSE
+  )
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    TRUE
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = TRUE),
+    0L
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    1L
+  )
+  expect_identical(
+    .g_match_motif(glycan_graph, motif_graph),
+    list(1L)
+  )
+})
+
 test_that(".g_match_motif retains original nodes across floating localizations", {
   glycan <- glyrepr::as_glycan_structure(
     "{Neu5Ac(a2-3)|2,3}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
@@ -176,5 +206,35 @@ test_that(".g_* motif functions support motifs assembled from floating parts", {
   expect_identical(
     .g_match_motif(glycan_graph, motif_graph),
     list(c(1L, 2L, 3L), c(1L, 2L, 4L))
+  )
+})
+
+test_that(".g_* motif functions jointly localize parts and substituents", {
+  glycan <- glyrepr::as_glycan_structure(
+    "{6S|2,3}{Fuc(a1-6)|2,3}Gal(a1-3)Glc(a1-"
+  )
+  motif <- glyrepr::as_glycan_structure("Gal6S(a1-")
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = TRUE),
+    FALSE
+  )
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    TRUE
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = TRUE),
+    0L
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    1L
+  )
+  expect_identical(
+    .g_match_motif(glycan_graph, motif_graph),
+    list(2L)
   )
 })

--- a/tests/testthat/test-g-motif.R
+++ b/tests/testthat/test-g-motif.R
@@ -115,7 +115,7 @@ test_that(".g_* motif functions recycle scalar match_degree like high-level API"
 
 test_that(".g_* motif functions aggregate floating localizations", {
   glycan <- glyrepr::as_glycan_structure(
-    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-"
+    "{Gal(a1-3)|2,3}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-"
   )
   motif <- glyrepr::as_glycan_structure("Gal(a1-3)Man(a1-")
   glycan_graph <- glyrepr::get_structure_graphs(glycan)
@@ -145,7 +145,7 @@ test_that(".g_* motif functions aggregate floating localizations", {
 
 test_that(".g_match_motif retains original nodes across floating localizations", {
   glycan <- glyrepr::as_glycan_structure(
-    "{Neu5Ac(a2-3)|1,2}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
+    "{Neu5Ac(a2-3)|2,3}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
   )
   motif <- glyrepr::as_glycan_structure("Neu5Ac(??-?)Gal(??-")
   glycan_graph <- glyrepr::get_structure_graphs(glycan)
@@ -159,7 +159,7 @@ test_that(".g_match_motif retains original nodes across floating localizations",
 
 test_that(".g_* motif functions support motifs assembled from floating parts", {
   glycan <- glyrepr::as_glycan_structure(
-    "{Gal(a1-3)|1,2}{Gal(a1-4)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+    "{Gal(a1-3)|3,4}{Gal(a1-4)|3,4}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
   )
   motif <- glyrepr::as_glycan_structure("Gal(a1-3)[Gal(a1-4)]Man(a1-")
   glycan_graph <- glyrepr::get_structure_graphs(glycan)

--- a/tests/testthat/test-g-motif.R
+++ b/tests/testthat/test-g-motif.R
@@ -112,3 +112,69 @@ test_that(".g_* motif functions recycle scalar match_degree like high-level API"
     unname(match_motif(glycan, motif, match_degree = TRUE)[[1]])
   )
 })
+
+test_that(".g_* motif functions aggregate floating localizations", {
+  glycan <- glyrepr::as_glycan_structure(
+    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-"
+  )
+  motif <- glyrepr::as_glycan_structure("Gal(a1-3)Man(a1-")
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = TRUE),
+    FALSE
+  )
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    TRUE
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = TRUE),
+    0L
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    1L
+  )
+  expect_identical(
+    .g_match_motif(glycan_graph, motif_graph),
+    list(c(1L, 2L))
+  )
+})
+
+test_that(".g_match_motif retains original nodes across floating localizations", {
+  glycan <- glyrepr::as_glycan_structure(
+    "{Neu5Ac(a2-3)|1,2}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
+  )
+  motif <- glyrepr::as_glycan_structure("Neu5Ac(??-?)Gal(??-")
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+
+  expect_identical(
+    .g_match_motif(glycan_graph, motif_graph),
+    list(c(1L, 2L), c(1L, 3L))
+  )
+})
+
+test_that(".g_* motif functions support motifs assembled from floating parts", {
+  glycan <- glyrepr::as_glycan_structure(
+    "{Gal(a1-3)|1,2}{Gal(a1-4)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  )
+  motif <- glyrepr::as_glycan_structure("Gal(a1-3)[Gal(a1-4)]Man(a1-")
+  glycan_graph <- glyrepr::get_structure_graphs(glycan)
+  motif_graph <- glyrepr::get_structure_graphs(motif)
+
+  expect_identical(
+    .g_have_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    TRUE
+  )
+  expect_identical(
+    .g_count_motif(glycan_graph, motif_graph, strict_floating = FALSE),
+    1L
+  )
+  expect_identical(
+    .g_match_motif(glycan_graph, motif_graph),
+    list(c(1L, 2L, 3L), c(1L, 2L, 4L))
+  )
+})

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -1315,12 +1315,12 @@ test_that("strict-floating mode works", {
   # only if it appears in all possible glycans derived from the floating parts.
   motif <- "Gal(a1-3)Man(a1-"
   glycans <- c(
-    "{Gal(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",  # implicit floating
-    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-",  # good on one parents
-    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"   # good on both parents
+    "{Gal(a1-3)}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # implicit floating
+    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # good on one parents
+    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-" # good on both parents
   )
 
-  res1 <- have_motif(glycans, motif)  # defaults to use strict-floating
+  res1 <- have_motif(glycans, motif) # defaults to use strict-floating
   res2 <- have_motif(glycans, motif, strict_floating = TRUE)
 
   expect_identical(res1, c(FALSE, FALSE, TRUE))
@@ -1332,14 +1332,15 @@ test_that("lenient-floating mode works", {
   # as long as it appears in one possible glycan derived from the floating parts.
   motif <- "Gal(a1-3)Man(a1-"
   glycans <- c(
-    "{Gal(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",  # implicit floating
-    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-",  # good on one parents
-    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"   # good on both parents
+    "{Gal(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-", # implicit floating
+    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # good on one parents
+    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-" # good on both parents
   )
 
+  res1 <- have_motif(glycans, motif, strict_floating = FALSE)
   res2 <- have_motif(glycans, motif, strict_floating = FALSE)
 
-  expect_identical(res1, c(FALSE, TRUE, TRUE))
+  expect_identical(res1, c(TRUE, TRUE, TRUE))
   expect_identical(res1, res2)
 })
 
@@ -1353,4 +1354,31 @@ test_that("have_motif detects new motifs assembled from two floating parts", {
   motif <- "Gal(a1-3)[Gal(a1-4)]Man(a1-"
   glycan <- "{Gal(a1-3)|1,2}{Gal(a1-4)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
   expect_true(have_motif(glycan, motif, strict_floating = FALSE))
+})
+
+test_that("have_motifs aggregates floating localizations per motif", {
+  glycan <- "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-"
+  motifs <- c(
+    gal_man = "Gal(a1-3)Man(a1-",
+    gal_glc = "Gal(a1-3)Glc(a1-"
+  )
+
+  expect_identical(
+    unname(have_motifs(glycan, motifs, strict_floating = TRUE)),
+    matrix(c(FALSE, FALSE), nrow = 1L)
+  )
+  expect_identical(
+    unname(have_motifs(glycan, motifs, strict_floating = FALSE)),
+    matrix(c(TRUE, TRUE), nrow = 1L)
+  )
+})
+
+test_that("floating motifs are rejected clearly", {
+  expect_snapshot(
+    have_motif(
+      "Gal(a1-3)Man(a1-",
+      "{Gal(a1-3)}Man(a1-3)GlcNAc(b1-"
+    ),
+    error = TRUE
+  )
 })

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -1297,7 +1297,7 @@ test_that("mode is validated", {
   )
 })
 
-# ========== Floating Parts ==========
+# ========== Floating Structures ==========
 test_that("motif in a floating part can be detected", {
   glycan <- "{Gal(a1-3)Glc(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
   motif <- "Gal(a1-3)Glc(a1-"
@@ -1373,11 +1373,67 @@ test_that("have_motifs aggregates floating localizations per motif", {
   )
 })
 
-test_that("floating motifs are rejected clearly", {
+test_that("floating substituents use strict-floating aggregation", {
+  glycans <- glyrepr::as_glycan_structure(c(
+    floating = "{6S}Gal(a1-3)Glc(a1-",
+    ordinary = "Gal6S(a1-3)Glc(a1-"
+  ))
+  motif <- glyrepr::as_glycan_structure("Gal6S(a1-")
+
+  expect_identical(
+    have_motif(glycans, motif, strict_floating = TRUE),
+    c(floating = FALSE, ordinary = TRUE)
+  )
+  expect_identical(
+    have_motif(glycans, motif, strict_floating = FALSE),
+    c(floating = TRUE, ordinary = TRUE)
+  )
+})
+
+test_that("have_motifs aggregates floating substituents per motif", {
+  glycan <- glyrepr::as_glycan_structure(
+    c(sample = "{6S}Gal(a1-3)Glc(a1-")
+  )
+  motifs <- glyrepr::as_glycan_structure(c(
+    gal = "Gal6S(a1-",
+    glc = "Glc6S(a1-"
+  ))
+
+  strict <- matrix(
+    c(FALSE, FALSE),
+    nrow = 1L,
+    dimnames = list("sample", c("gal", "glc"))
+  )
+  possible <- matrix(
+    c(TRUE, TRUE),
+    nrow = 1L,
+    dimnames = list("sample", c("gal", "glc"))
+  )
+  expect_identical(
+    have_motifs(glycan, motifs, strict_floating = TRUE),
+    strict
+  )
+  expect_identical(
+    have_motifs(glycan, motifs, strict_floating = FALSE),
+    possible
+  )
+})
+
+test_that("floating parts in motifs are rejected clearly", {
   expect_snapshot(
     have_motif(
       "Gal(a1-3)Man(a1-",
       "{Gal(a1-3)}Man(a1-3)GlcNAc(b1-"
+    ),
+    error = TRUE
+  )
+})
+
+test_that("floating substituents in motifs are rejected clearly", {
+  expect_snapshot(
+    have_motif(
+      "Gal6S(a1-3)Glc(a1-",
+      "{6S}Gal(a1-3)Glc(a1-"
     ),
     error = TRUE
   )

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -1296,3 +1296,61 @@ test_that("mode is validated", {
     "`mode` must be"
   )
 })
+
+# ========== Floating Parts ==========
+test_that("motif in a floating part can be detected", {
+  glycan <- "{Gal(a1-3)Glc(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  motif <- "Gal(a1-3)Glc(a1-"
+  expect_true(have_motif(glycan, motif))
+})
+
+test_that("motif in a non-floating part can be detected", {
+  glycan <- "{Gal(a1-3)Glc(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  motif <- "Man(a1-3)GlcNAc(b1-"
+  expect_true(have_motif(glycan, motif))
+})
+
+test_that("strict-floating mode works", {
+  # In the strict-floating mode, a motif is regarded to exist
+  # only if it appears in all possible glycans derived from the floating parts.
+  motif <- "Gal(a1-3)Man(a1-"
+  glycans <- c(
+    "{Gal(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",  # implicit floating
+    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-",  # good on one parents
+    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"   # good on both parents
+  )
+
+  res1 <- have_motif(glycans, motif)  # defaults to use strict-floating
+  res2 <- have_motif(glycans, motif, strict_floating = TRUE)
+
+  expect_identical(res1, c(FALSE, FALSE, TRUE))
+  expect_identical(res1, res2)
+})
+
+test_that("lenient-floating mode works", {
+  # In the lenient-floating mode, a motif is regarded to exist
+  # as long as it appears in one possible glycan derived from the floating parts.
+  motif <- "Gal(a1-3)Man(a1-"
+  glycans <- c(
+    "{Gal(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-",  # implicit floating
+    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-",  # good on one parents
+    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"   # good on both parents
+  )
+
+  res2 <- have_motif(glycans, motif, strict_floating = FALSE)
+
+  expect_identical(res1, c(FALSE, TRUE, TRUE))
+  expect_identical(res1, res2)
+})
+
+test_that("have_motif works for multiple floating parts", {
+  motif <- "Gal(a1-3)Man(a1-"
+  glycan <- "{Gal(a1-3)|1,2}{Glc(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  expect_true(have_motif(glycan, motif, strict_floating = FALSE))
+})
+
+test_that("have_motif detects new motifs assembled from two floating parts", {
+  motif <- "Gal(a1-3)[Gal(a1-4)]Man(a1-"
+  glycan <- "{Gal(a1-3)|1,2}{Gal(a1-4)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  expect_true(have_motif(glycan, motif, strict_floating = FALSE))
+})

--- a/tests/testthat/test-have-motif.R
+++ b/tests/testthat/test-have-motif.R
@@ -1316,8 +1316,8 @@ test_that("strict-floating mode works", {
   motif <- "Gal(a1-3)Man(a1-"
   glycans <- c(
     "{Gal(a1-3)}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # implicit floating
-    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # good on one parents
-    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-" # good on both parents
+    "{Gal(a1-3)|2,3}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # good on one parents
+    "{Gal(a1-3)|2,3}Man(a1-3)[Man(a1-6)]GlcNAc(b1-" # good on both parents
   )
 
   res1 <- have_motif(glycans, motif) # defaults to use strict-floating
@@ -1333,8 +1333,8 @@ test_that("lenient-floating mode works", {
   motif <- "Gal(a1-3)Man(a1-"
   glycans <- c(
     "{Gal(a1-3)}Man(a1-3)[Man(a1-6)]GlcNAc(b1-", # implicit floating
-    "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # good on one parents
-    "{Gal(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-" # good on both parents
+    "{Gal(a1-3)|2,3}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-", # good on one parents
+    "{Gal(a1-3)|2,3}Man(a1-3)[Man(a1-6)]GlcNAc(b1-" # good on both parents
   )
 
   res1 <- have_motif(glycans, motif, strict_floating = FALSE)
@@ -1346,18 +1346,18 @@ test_that("lenient-floating mode works", {
 
 test_that("have_motif works for multiple floating parts", {
   motif <- "Gal(a1-3)Man(a1-"
-  glycan <- "{Gal(a1-3)|1,2}{Glc(a1-3)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  glycan <- "{Gal(a1-3)|3,4}{Glc(a1-3)|3,4}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
   expect_true(have_motif(glycan, motif, strict_floating = FALSE))
 })
 
 test_that("have_motif detects new motifs assembled from two floating parts", {
   motif <- "Gal(a1-3)[Gal(a1-4)]Man(a1-"
-  glycan <- "{Gal(a1-3)|1,2}{Gal(a1-4)|1,2}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
+  glycan <- "{Gal(a1-3)|3,4}{Gal(a1-4)|3,4}Man(a1-3)[Man(a1-6)]GlcNAc(b1-"
   expect_true(have_motif(glycan, motif, strict_floating = FALSE))
 })
 
 test_that("have_motifs aggregates floating localizations per motif", {
-  glycan <- "{Gal(a1-3)|1,2}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-"
+  glycan <- "{Gal(a1-3)|2,3}Man(a1-3)[Glc(a1-6)]GlcNAc(b1-"
   motifs <- c(
     gal_man = "Gal(a1-3)Man(a1-",
     gal_glc = "Gal(a1-3)Glc(a1-"

--- a/tests/testthat/test-match-motif.R
+++ b/tests/testthat/test-match-motif.R
@@ -609,3 +609,21 @@ test_that("match_motif retains mappings from canonical duplicate localizations",
     list(list(c(1L, 2L), c(1L, 3L)))
   )
 })
+
+test_that("match_motifs unions floating substituent mappings", {
+  glycan <- glyrepr::as_glycan_structure(
+    c(sample = "{6S}Gal(a1-3)Glc(a1-")
+  )
+  motifs <- glyrepr::as_glycan_structure(c(
+    gal = "Gal6S(a1-",
+    glc = "Glc6S(a1-"
+  ))
+
+  expect_identical(
+    match_motifs(glycan, motifs),
+    list(
+      gal = list(sample = list(1L)),
+      glc = list(sample = list(2L))
+    )
+  )
+})

--- a/tests/testthat/test-match-motif.R
+++ b/tests/testthat/test-match-motif.R
@@ -586,8 +586,26 @@ test_that("match_motif works for floating parts", {
   # all possible matches, but the two others have to condense the matches into one value.
   motif <- "Gal(??-?)GlcNAc(??-?)Gal(??-"
   glycan <- "{Gal(??-?)GlcNAc(??-?)}Gal(??-?)GlcNAc(??-?)Gal(??-"
+  motif <- glyparse::parse_iupac_condensed(motif)
+  glycan <- glyparse::parse_iupac_condensed(glycan)
 
   result <- match_motif(glycan, motif)
-  expected <- list(c(1L, 2L, 3L), c(1L, 2L, 5L))
+  expected <- list(list(
+    c(1L, 2L, 3L),
+    c(3L, 4L, 5L),
+    c(1L, 2L, 5L)
+  ))
   expect_identical(result, expected)
+})
+
+test_that("match_motif retains mappings from canonical duplicate localizations", {
+  glycan <- glyparse::parse_iupac_condensed(
+    "{Neu5Ac(a2-3)|1,2}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
+  )
+  motif <- glyparse::parse_iupac_condensed("Neu5Ac(??-?)Gal(??-")
+
+  expect_identical(
+    match_motif(glycan, motif),
+    list(list(c(1L, 2L), c(1L, 3L)))
+  )
 })

--- a/tests/testthat/test-match-motif.R
+++ b/tests/testthat/test-match-motif.R
@@ -579,3 +579,15 @@ test_that("match_motif supports lenient mode", {
     list(list(c(1, 2)))
   )
 })
+
+test_that("match_motif works for floating parts", {
+  # Unlike `have_motif()` or `count_motif()`, `match_motif()` don't have the
+  # `strict_floating` argument, as the nature of this function is to return
+  # all possible matches, but the two others have to condense the matches into one value.
+  motif <- "Gal(??-?)GlcNAc(??-?)Gal(??-"
+  glycan <- "{Gal(??-?)GlcNAc(??-?)}Gal(??-?)GlcNAc(??-?)Gal(??-"
+
+  result <- match_motif(glycan, motif)
+  expected <- list(c(1L, 2L, 3L), c(1L, 2L, 5L))
+  expect_identical(result, expected)
+})

--- a/tests/testthat/test-match-motif.R
+++ b/tests/testthat/test-match-motif.R
@@ -600,7 +600,7 @@ test_that("match_motif works for floating parts", {
 
 test_that("match_motif retains mappings from canonical duplicate localizations", {
   glycan <- glyparse::parse_iupac_condensed(
-    "{Neu5Ac(a2-3)|1,2}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
+    "{Neu5Ac(a2-3)|2,3}Gal(??-?)[Gal(??-?)]GlcNAc(??-"
   )
   motif <- glyparse::parse_iupac_condensed("Neu5Ac(??-?)Gal(??-")
 


### PR DESCRIPTION
## Summary

- Support unresolved floating parts and substituents across `have_motif()`, `count_motif()`, `match_motif()`, and their plural variants.
- Add `strict_floating` aggregation for logical and count results.
- Extend low-level `.g_*()` matchers while preserving original node indices in returned mappings.
- Add documentation and regression coverage for floating localization behavior.

## Verification

- `devtools::test()` — 618 passed.
- `pkgdown::check_pkgdown()` — no problems found.
- `devtools::check()` — 0 errors, 0 warnings, 1 environment clock NOTE.
- `git diff --check` — clean.